### PR TITLE
Occurrences

### DIFF
--- a/permuta/permutation.py
+++ b/permuta/permutation.py
@@ -85,25 +85,28 @@ class Permutation(object):
 
     def occurrences_in(self, perm):
         """Returns the occurrences of the pattern self in the permutation perm."""
-        def con(i, now, indexes):
-            if len(now) == len(self):
-                return [indexes]
+        def con(i, now, indices, k):
+            # Length of the occurrence has reached length of pattern
+            if k == len(self):
+                yield indices
 
+            # Reached end of permutation and occurrence is not long enough
             if i == len(perm):
-                return []
+                return
 
-            occurrences = []
-            nxt = now + [perm[i]]
+            now[k] = perm[i]
+            k += 1
             # TODO: make this faster by incrementally building flattened list
-            if (Permutation.to_standard(nxt) ==
-                    Permutation.to_standard(self[:len(nxt)])):
-                occurrences += con(i+1, nxt, indexes +[i])
+            if (Permutation.to_standard(now[:k]) == Permutation.to_standard(self[:k])):
+                indices[k-1] = i
+                for o in con(i+1, now, indices, k):
+                    yield o
 
-            occurrences += con(i+1, now, indexes)
+            for o in con(i+1, now, indices, k):
+                yield o
 
-            return occurrences
-
-        return con(0, [], [])
+        for o in con(0, []*len(self), []*len(self), 0):
+            yield o
 
     def occurrences_of(self, patt):
         """Returns the occurrences of the pattern patt in the permutation self."""

--- a/permuta/permutation.py
+++ b/permuta/permutation.py
@@ -85,30 +85,61 @@ class Permutation(object):
 
     def occurrences_in(self, perm):
         """Returns the occurrences of the pattern self in the permutation perm."""
+
+        # Memoize all prefix flattenings of the pattern self
+        k_standard_patt = [Permutation.to_standard(self[:k]) for k in range(0, len(self))]
+        k_standard_patt.append(self)
+
+        # These two lists define a pattern in the permutation perm
+        # occurrence is the actual elements and indices is their indices in perm
         occurrence = [None]*len(self)
         indices = occurrence[:]
-        def con(i, k):
+
+        # Define function that works with the above defined variables
+        # i is the index of the element in perm that is to be considered
+        # k is how many elements of the permutation have already been added to occurrence
+        # flattened is the flattened occurrence so far
+        def con(i, k, flattened):
             # Length of the occurrence has reached length of pattern
             if k == len(self):
                 yield indices[:]
                 return
 
             # Reached end of permutation and occurrence is not long enough
+            # or won't reach length of pattern at all
             if i == len(perm):
                 return
 
-            # TODO: make this faster by incrementally building flattened list
-            
-            occurrence[k] = perm[i]
-            if (Permutation.to_standard(occurrence[:(k+1)])
-                   == Permutation.to_standard(self[:(k+1)])):
+            # Incrementally build flattened occurrence
+            new_element = perm[i]
+            new_flattened = [
+                              flattened[n]
+                              if occurrence[n] < new_element
+                              else
+                              flattened[n]+1
+                              for n in range(k)
+                            ]
+            new_element_flattened = 1+ len([ 
+                                             n
+                                             for n in range(k)
+                                             if flattened[n] == new_flattened[n]
+                                           ])
+            new_flattened.append(new_element_flattened)
+            new_flattened = Permutation(new_flattened)
+
+            # Add element to occurrence and see if pattern can be found
+            occurrence[k] = new_element
+            if new_flattened == k_standard_patt[k+1]:
+                # Still conforms to pattern, so add index and look further
                 indices[k] = i
-                for o in con(i+1, k+1):
+                for o in con(i+1, k+1, new_flattened):
                     yield o
-            for o in con(i+1, k):
+
+            # Yield occurrences where the ith element is not chosen
+            for o in con(i+1, k, flattened):
                 yield o
 
-        for o in con(0, 0):
+        for o in con(0, 0, []):
             yield o
 
     def occurrences_of(self, patt):

--- a/permuta/permutation.py
+++ b/permuta/permutation.py
@@ -86,7 +86,7 @@ class Permutation(object):
     def occurrences_in(self, perm):
         """Returns the occurrences of the pattern self in the permutation perm."""
 
-        # Memoize all prefix flattenings of the pattern self
+        # Calculate all prefix flattenings of the pattern self
         k_standard_patt = [Permutation.to_standard(self[:k]) for k in range(0, len(self))]
         k_standard_patt.append(self)
 
@@ -100,15 +100,19 @@ class Permutation(object):
         # k is how many elements of the permutation have already been added to occurrence
         # flattened is the flattened occurrence so far
         def con(i, k, flattened):
+
             # Length of the occurrence has reached length of pattern
             if k == len(self):
                 yield indices[:]
                 return
 
-            # Reached end of permutation and occurrence is not long enough
-            # or won't reach length of pattern at all
-            if i == len(perm):
+            # Not enough elements left to make occurrence
+            elements_left = len(perm) - i
+            elements_needed = len(self) - k
+            if elements_left < elements_needed:
                 return
+
+            # TODO: Optimize if elements_left == elements_needed?
 
             # Incrementally build flattened occurrence
             new_element = perm[i]
@@ -119,18 +123,17 @@ class Permutation(object):
                               flattened[n]+1
                               for n in range(k)
                             ]
-            new_element_flattened = 1+ len([ 
-                                             n
-                                             for n in range(k)
-                                             if flattened[n] == new_flattened[n]
-                                           ])
+            new_element_flattened = 1 + len([
+                                              n for n in range(k)
+                                              if flattened[n] == new_flattened[n]
+                                            ])
             new_flattened.append(new_element_flattened)
             new_flattened = Permutation(new_flattened)
 
-            # Add element to occurrence and see if pattern can be found
-            occurrence[k] = new_element
+            # Yield occurrences where the ith element is chosen
             if new_flattened == k_standard_patt[k+1]:
                 # Still conforms to pattern, so add index and look further
+                occurrence[k] = new_element
                 indices[k] = i
                 for o in con(i+1, k+1, new_flattened):
                     yield o

--- a/permuta/permutation.py
+++ b/permuta/permutation.py
@@ -85,27 +85,30 @@ class Permutation(object):
 
     def occurrences_in(self, perm):
         """Returns the occurrences of the pattern self in the permutation perm."""
-        def con(i, now, indices, k):
+        occurrence = [None]*len(self)
+        indices = occurrence[:]
+        def con(i, k):
             # Length of the occurrence has reached length of pattern
             if k == len(self):
-                yield indices
+                yield indices[:]
+                return
 
             # Reached end of permutation and occurrence is not long enough
             if i == len(perm):
                 return
 
-            now[k] = perm[i]
-            k += 1
             # TODO: make this faster by incrementally building flattened list
-            if (Permutation.to_standard(now[:k]) == Permutation.to_standard(self[:k])):
-                indices[k-1] = i
-                for o in con(i+1, now, indices, k):
+            
+            occurrence[k] = perm[i]
+            if (Permutation.to_standard(occurrence[:(k+1)])
+                   == Permutation.to_standard(self[:(k+1)])):
+                indices[k] = i
+                for o in con(i+1, k+1):
                     yield o
-
-            for o in con(i+1, now, indices, k):
+            for o in con(i+1, k):
                 yield o
 
-        for o in con(0, []*len(self), []*len(self), 0):
+        for o in con(0, 0):
             yield o
 
     def occurrences_of(self, patt):

--- a/tests/test_permutation.py
+++ b/tests/test_permutation.py
@@ -55,13 +55,13 @@ class TestPermutation(unittest.TestCase):
         self.assertEqual(Permutation([1]).count_occurrences_in(Permutation([5,2,3,4,1])), 5)
         self.assertEqual(Permutation([1,2]).count_occurrences_in(Permutation([5,2,3,4,1])), 3)
         self.assertEqual(Permutation([2,1]).count_occurrences_in(Permutation([5,2,3,4,1])), 7)
-        self.assertEqual(Permutation([5,2,3,4,1]).count_occurrences_in(Permutation([])), 1)
+        self.assertEqual(Permutation([5,2,3,4,1]).count_occurrences_in(Permutation([])), 0)
         self.assertEqual(Permutation([5,2,3,4,1]).count_occurrences_in(Permutation([2,1])), 0)
 
     def test_occurrences_in(self):
         self.assertEqual(
                           sorted(Permutation([]).occurrences_in(Permutation([5,2,3,4,1])))
-                        , sorted([[]])
+                        , [[]]
                         )
         self.assertEqual( 
                           sorted(Permutation([1]).occurrences_in(Permutation([5,2,3,4,1])))
@@ -75,8 +75,8 @@ class TestPermutation(unittest.TestCase):
                           sorted(Permutation([2,1]).occurrences_in(Permutation([5,2,3,4,1])))
                         , sorted([[0,1],[0,2],[0,3],[0,4],[1,4],[2,4],[3,4]])
                         )
-        self.assertEqual(sorted(Permutation([5,2,3,4,1]).occurrences_in(Permutation([]))), sorted([]))
-        self.assertEqual(sorted(Permutation([5,2,3,4,1]).occurrences_in(Permutation([2,1]))), sorted([]))
+        self.assertEqual(sorted(Permutation([5,2,3,4,1]).occurrences_in(Permutation([]))), [])
+        self.assertEqual(sorted(Permutation([5,2,3,4,1]).occurrences_in(Permutation([2,1]))), [])
 
     def test_inverse(self):
         for i in range(10):

--- a/tests/test_permutation.py
+++ b/tests/test_permutation.py
@@ -50,6 +50,34 @@ class TestPermutation(unittest.TestCase):
         self.assertFalse(Permutation([3, 1, 2, 4]).contained_in(Permutation([6, 4, 3, 8, 2, 1, 7, 5])))
         self.assertFalse(Permutation([1, 2, 3, 4]).contained_in(Permutation([5, 8, 6, 2, 7, 3, 4, 1])))
 
+    def test_count_occurrences_in(self):
+        self.assertEqual(Permutation([]).count_occurrences_in(Permutation([5,2,3,4,1])), 1)
+        self.assertEqual(Permutation([1]).count_occurrences_in(Permutation([5,2,3,4,1])), 5)
+        self.assertEqual(Permutation([1,2]).count_occurrences_in(Permutation([5,2,3,4,1])), 3)
+        self.assertEqual(Permutation([2,1]).count_occurrences_in(Permutation([5,2,3,4,1])), 7)
+        self.assertEqual(Permutation([5,2,3,4,1]).count_occurrences_in(Permutation([])), 1)
+        self.assertEqual(Permutation([5,2,3,4,1]).count_occurrences_in(Permutation([2,1])), 0)
+
+    def test_occurrences_in(self):
+        self.assertEqual(
+                          sorted(Permutation([]).occurrences_in(Permutation([5,2,3,4,1])))
+                        , sorted([[]])
+                        )
+        self.assertEqual( 
+                          sorted(Permutation([1]).occurrences_in(Permutation([5,2,3,4,1])))
+                        , sorted([[0],[1],[2],[3],[4]])
+                        )
+        self.assertEqual(
+                          sorted(Permutation([1,2]).occurrences_in(Permutation([5,2,3,4,1])))
+                        , sorted([[1,2],[1,3],[2,3]])
+                        )
+        self.assertEqual(
+                          sorted(Permutation([2,1]).occurrences_in(Permutation([5,2,3,4,1])))
+                        , sorted([[0,1],[0,2],[0,3],[0,4],[1,4],[2,4],[3,4]])
+                        )
+        self.assertEqual(sorted(Permutation([5,2,3,4,1]).occurrences_in(Permutation([]))), sorted([]))
+        self.assertEqual(sorted(Permutation([5,2,3,4,1]).occurrences_in(Permutation([2,1]))), sorted([]))
+
     def test_inverse(self):
         for i in range(10):
             self.assertEqual(Permutation(range(1,i)), Permutation(range(1,i)).inverse())


### PR DESCRIPTION
I took your comments (bar the iterator one) to heart and both created tests for and modified the occurrence function. Instead of using append I set the size of the occurrences/indices at the start and yielded shallow copies. I tried using append as well and when I timed it, it seemed to be about equivalent time wise. After doing that I decided to pre-calculate the to_standard prefixes of the pattern (maybe this could be a function in permuta? prefix_standards?) which resulted in a considerable performance boost, and then incrementally building the flattened occurrence (which I hope I did the way you wanted) which also seems to have contributed a performance boost. Then I changed the condition for when we've run out of elements from the permutation to consider.
All in all, hope you approve of these modifications, but if you have any pointers, I'd gladly look into them.
Cheers!