### PR TITLE
Mesh plotting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- The ascii_plot, and to_tikz method in MeshPatt
+### Removed
+- The broken latex method in MeshPatt
+
 ## [1.0.0] - 2019-04-15
 ### Added
 - Made master branch deploy to PyPi.

--- a/permuta/meshpatt.py
+++ b/permuta/meshpatt.py
@@ -831,33 +831,34 @@ class MeshPatt(MeshPatternBase, Patt, Rotatable, Shiftable, Flippable):
         s = ''.join(roundrobin(vlines, lines))
         return s[:-1]
 
-    def latex(self, scale=0.3):  # pragma: no cover
-        """Returns the LaTeX code for the TikZ figure of the mesh pattern. The
-        LaTeX code requires the TikZ library 'patterns'.
-
-        Args:
-            scale: <numbers.Real>
-                The scale of the image.
+    def to_tikz(self):
+        """
+        Return the tikz code to plot the mesh pattern. The tikz code requires
+        the TikZ library patter.
 
         Returns: str
             The LaTeX code for the TikZ figure of the pattern.
         """
-        # TODO: Review
-        return ("\\raisebox{{0.6ex}}{{\n"
-                "\\begin{{tikzpicture}}"
-                "[baseline=(current bounding box.center),scale={0}]\n"
-                "\\useasboundingbox (0.0,-0.1) rectangle ({1}+1.4,{1}+1.1);\n"
-                "\\foreach \\x/\\y in {{{3}}}\n"
-                "  \\fill[pattern color = black!65, pattern=north east lines] "
-                "(\\x,\\y) rectangle +(1,1);\n"
-                "\\draw (0.01,0.01) grid ({1}+0.99,{1}+0.99);\n"
-                "\\foreach [count=\\x] \\y in {{{2}}}\n"
-                "  \\filldraw (\\x,\\y) circle (6pt);\n"
-                "\\end{{tikzpicture}}}}"
-                ).format(scale, len(self.pattern),
-                         ','.join(map(str, self.pattern)),
-                         ','.join(["{}/{}".format(p[0], p[1])
-                                   for p in self.shading]))
+        s = r'\begin{tikzpicture}'
+        s += r'[scale=.3,baseline=(current bounding box.center)]'
+        s += '\n\t'
+        s += r'\foreach \x in {1,...,'+str(len(self))+'} {'
+        s += '\n\t\t'
+        s += r'\draw[ultra thin] (\x,0)--(\x,'+str(len(self)+1)+'); %vline'
+        s += '\n\t\t'
+        s += r'\draw[ultra thin] (0,\x)--('+str(len(self)+1) + r',\x); %hline'
+        s += 2*'\n\t'
+        s += r'}'
+        for cell in self.shading:
+            s += '\n\t'
+            s += r'\fill[pattern color = black!75, pattern=north east lines] '
+            s += str(cell) + r' rectangle +(1,1);'
+        for (i, e) in enumerate(self.pattern):
+            s += '\n\t'
+            s += r'\draw[fill=black] ('+str(i+1)+','+str(e+1)+') circle (5pt);'
+        s += '\n'
+        s += r'\end{tikzpicture}'
+        return s
 
     #
     # Static methods

--- a/tests/test_meshpatt.py
+++ b/tests/test_meshpatt.py
@@ -451,6 +451,17 @@ def test_eq():
     assert mesh2copy == mesh2copy
     assert mesh3copy == mesh3copy
 
+def test_to_tikz():
+    assert (mesh_pattern.to_tikz() ==
+            '\\begin{tikzpicture}[scale=.3,baseline=(current bounding box.center)]\n\t\\foreach \\x in {1,...,4} {\n\t\t\\draw[ultra thin] (\\x,0)--(\\x,5); %vline\n\t\t\\draw[ultra thin] (0,\\x)--(5,\\x); %hline\n\t\n\t}\n\t\\fill[pattern color = black!75, pattern=north east lines] (0, 0) rectangle +(1,1);\n\t\\fill[pattern color = black!75, pattern=north east lines] (4, 0) rectangle +(1,1);\n\t\\fill[pattern color = black!75, pattern=north east lines] (2, 1) rectangle +(1,1);\n\t\\fill[pattern color = black!75, pattern=north east lines] (4, 1) rectangle +(1,1);\n\t\\fill[pattern color = black!75, pattern=north east lines] (2, 2) rectangle +(1,1);\n\t\\fill[pattern color = black!75, pattern=north east lines] (4, 2) rectangle +(1,1);\n\t\\fill[pattern color = black!75, pattern=north east lines] (3, 3) rectangle +(1,1);\n\t\\fill[pattern color = black!75, pattern=north east lines] (0, 4) rectangle +(1,1);\n\t\\draw[fill=black] (1,2) circle (5pt);\n\t\\draw[fill=black] (2,4) circle (5pt);\n\t\\draw[fill=black] (3,3) circle (5pt);\n\t\\draw[fill=black] (4,1) circle (5pt);\n\\end{tikzpicture}'
+           )
+
+def test_ascii_plot():
+    assert (mesh_pattern.ascii_plot() ==
+            '▒| | | | \n-+-●-+-+-\n | | |▒| \n-+-+-●-+-\n | |▒| |▒\n-●-+-+-+-\n'
+            ' | |▒| |▒\n-+-+-+-●-\n▒| | | |▒')
+
+
 # def test_gen_meshpatts():
 def gen_meshpatts():
     assert list(gen_meshpatts(0)) == [MeshPatt(), MeshPatt((), [(0, 0)])]


### PR DESCRIPTION
Summary of changes:

- [x] Added a `ascii_plot` method for mesh patterns

- [x] Remove the broken method `MeshPatt.latex` and replace it with `MeshPatt.to_tikz`. I change the name of the method for consistency with the Perm class.