### PR TITLE
Enumeration strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-- `MeshPatt`s are now comparable (i.e. a mesh patt is always less then, 
+
+### Added
+- `MeshPatt`s are now comparable (i.e. a mesh patt is always less then,
   equal to or greater than another mesh patt) and therefore sortable
+- Added enumeration strategies that can point out to useful results to find the
+  enumeration of a permutation class.
 
 ## [1.2.1] - 2019-09-10
 ### Fixed

--- a/permuta/enumeration_strategies/__init__.py
+++ b/permuta/enumeration_strategies/__init__.py
@@ -7,3 +7,21 @@ long_enumeration_strategies = []
 
 all_enumeration_strategies = (fast_enumeration_strategies +
                               long_enumeration_strategies)
+
+
+def find_strategies(basis, long_runnning=True):
+    """
+    Test all enumeration strategies against the basis and return a list of
+    potentially useful strategies. If `long_runnning` is False, test only the
+    strategies that can be tested quickly.
+    """
+    if long_runnning:
+        strategies = all_enumeration_strategies
+    else:
+        strategies = fast_enumeration_strategies
+    working_strategies = []
+    for Strategy in strategies:
+        strategy_object = Strategy(basis)
+        if strategy_object.applies():
+            working_strategies.append(strategy_object)
+    return working_strategies

--- a/permuta/enumeration_strategies/__init__.py
+++ b/permuta/enumeration_strategies/__init__.py
@@ -1,6 +1,7 @@
+from .core_strategies import core_strategies
 from .insertion_encodable import InsertionEncodingStrategy
 
-fast_enumeration_strategies = [InsertionEncodingStrategy]
+fast_enumeration_strategies = [InsertionEncodingStrategy] + core_strategies
 
 long_enumeration_strategies = []
 

--- a/permuta/enumeration_strategies/__init__.py
+++ b/permuta/enumeration_strategies/__init__.py
@@ -1,0 +1,8 @@
+from .insertion_encodable import InsertionEncodingStrategy
+
+fast_enumeration_strategies = [InsertionEncodingStrategy]
+
+long_enumeration_strategies = []
+
+all_enumeration_strategies = (fast_enumeration_strategies +
+                              long_enumeration_strategies)

--- a/permuta/enumeration_strategies/abstract_strategy.py
+++ b/permuta/enumeration_strategies/abstract_strategy.py
@@ -48,7 +48,6 @@ class EnumerationStrategyWithSymmetry(EnumerationStrategy):
             self.applies()
         return self._basis
 
-
     def applies(self):
         """
         Check if the strategy applies to any symmetry.

--- a/permuta/enumeration_strategies/abstract_strategy.py
+++ b/permuta/enumeration_strategies/abstract_strategy.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 
+
 class EnumerationStrategy(ABC):
 
     """Abstract class for a strategy to enumerate a permutation classes"""

--- a/permuta/enumeration_strategies/abstract_strategy.py
+++ b/permuta/enumeration_strategies/abstract_strategy.py
@@ -8,7 +8,7 @@ class EnumerationStrategy(ABC):
 
     def __init__(self, basis):
         ABC.__init__(self)
-        self._basis = basis
+        self._basis = frozenset(basis)
 
     @property
     def basis(self):
@@ -53,7 +53,7 @@ class EnumerationStrategyWithSymmetry(EnumerationStrategy):
         """
         Check if the strategy applies to any symmetry.
         """
-        for b in map(set, all_symmetry_sets(self._basis)):
+        for b in map(frozenset, all_symmetry_sets(self._basis)):
             if self._applies_to_symmetry(b):
                 self._apply_basis = b
                 return True

--- a/permuta/enumeration_strategies/abstract_strategy.py
+++ b/permuta/enumeration_strategies/abstract_strategy.py
@@ -1,8 +1,9 @@
 from abc import ABC, abstractmethod
 
+from permuta.permutils.symmetry import all_symmetry_sets
+
 
 class EnumerationStrategy(ABC):
-
     """Abstract class for a strategy to enumerate a permutation classes"""
 
     def __init__(self, basis):
@@ -23,5 +24,44 @@ class EnumerationStrategy(ABC):
     def applies(self):
         """
         Return True if the strategy can be used for the basis
+        """
+        pass
+
+
+class EnumerationStrategyWithSymmetry(EnumerationStrategy):
+    """
+    Abstract class for a strategy to enumerate a permutation classes.
+
+    Each symmetry of the inputed basis is tested against the strategy.
+    """
+
+    def __init__(self, basis):
+        super().__init__(basis)
+        self._apply_basis = None
+
+    @property
+    def basis(self):
+        """
+        The symmetry of the inputed basis to which the strategy applies to.
+        """
+        if self._basis is None:
+            self.applies()
+        return self._basis
+
+
+    def applies(self):
+        """
+        Check if the strategy applies to any symmetry.
+        """
+        for b in map(set, all_symmetry_sets(self._basis)):
+            if self._applies_to_symmetry(b):
+                self._apply_basis = b
+                return True
+        return False
+
+    @abstractmethod
+    def _applies_to_symmetry(self, b):
+        """
+        Check if the strategy applies to this particular symmetry.
         """
         pass

--- a/permuta/enumeration_strategies/abstract_strategy.py
+++ b/permuta/enumeration_strategies/abstract_strategy.py
@@ -1,0 +1,26 @@
+from abc import ABC, abstractmethod
+
+class EnumerationStrategy(ABC):
+
+    """Abstract class for a strategy to enumerate a permutation classes"""
+
+    def __init__(self, basis):
+        ABC.__init__(self)
+        self._basis = basis
+
+    @property
+    def basis(self):
+        return self._basis
+
+    @property
+    @staticmethod
+    def reference():
+        """A reference for the strategy."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def applies(self):
+        """
+        Return True if the strategy can be used for the basis
+        """
+        pass

--- a/permuta/enumeration_strategies/abstract_strategy.py
+++ b/permuta/enumeration_strategies/abstract_strategy.py
@@ -14,9 +14,8 @@ class EnumerationStrategy(ABC):
     def basis(self):
         return self._basis
 
-    @property
-    @staticmethod
-    def reference():
+    @classmethod
+    def reference(cls):
         """A reference for the strategy."""
         raise NotImplementedError
 

--- a/permuta/enumeration_strategies/core_strategies.py
+++ b/permuta/enumeration_strategies/core_strategies.py
@@ -12,6 +12,7 @@ C_D = Perm((2, 0, 3, 1))
 
 # Abstract Core Strategy
 
+
 class CoreStrategy(EnumerationStrategyWithSymmetry):
     """
     Abstract class for a core related strategy.
@@ -145,7 +146,7 @@ class RdCuCoreStrategy(CoreStrategy):
     @staticmethod
     def is_valid_extension(patt):
         return zero_plus_skewind(patt) and \
-                not bstrip(fstrip(patt)).sum_decomposable()
+            not bstrip(fstrip(patt)).sum_decomposable()
 
 
 class Rd2134CoreStrategy(CoreStrategy):

--- a/permuta/enumeration_strategies/core_strategies.py
+++ b/permuta/enumeration_strategies/core_strategies.py
@@ -3,7 +3,7 @@ from abc import abstractmethod, abstractproperty, abstractstaticmethod
 from permuta import Av, MeshPatt, Perm
 from permuta.descriptors import Basis
 from permuta.enumeration_strategies.abstract_strategy import \
-    EnumerationStrategy
+    EnumerationStrategyWithSymmetry
 
 R_U = Perm((1, 2, 0, 3))
 C_U = Perm((2, 0, 1, 3))
@@ -12,8 +12,7 @@ C_D = Perm((2, 0, 3, 1))
 
 # Abstract Core Strategy
 
-
-class CoreStrategy(EnumerationStrategy):
+class CoreStrategy(EnumerationStrategyWithSymmetry):
     """
     Abstract class for a core related strategy.
     """
@@ -33,8 +32,15 @@ class CoreStrategy(EnumerationStrategy):
         """
         pass
 
-    def applies(self):
-        b = set(self.basis)
+    def _applies_to_symmetry(self, b):
+        """
+        Check if the core strategy applies to the basis or any of its symmetry.
+
+        INPUT:
+
+        - `b`: a set of permutations.
+        """
+        assert isinstance(b, set)
         perm_class = Av(b)
         patterns_are_contained = all(p not in perm_class for p in
                                      self.patterns_needed)
@@ -75,7 +81,7 @@ def bstrip(perm):
         return perm
 
 
-def one_plus_skewind(perm):
+def zero_plus_skewind(perm):
     """
     Return True if the permutation is of the form 1 + p where p is a
     skew-indecomposable permutations
@@ -83,7 +89,7 @@ def one_plus_skewind(perm):
     return perm[0] == 0 and not fstrip(perm).skew_decomposable()
 
 
-def one_plus_sumind(perm):
+def zero_plus_sumind(perm):
     """
     Return True if the permutation is of the form 1 + p where p is a
     sum-indecomposable permutations
@@ -91,7 +97,10 @@ def one_plus_sumind(perm):
     return perm[0] == 0 and not fstrip(perm).sum_decomposable()
 
 
-def one_plus_perm(perm):
+def zero_plus_perm(perm):
+    """
+    Return True if the permutation starts with a zero.
+    """
     return perm[0] == 0
 
 
@@ -103,7 +112,7 @@ class RuCuCoreStrategy(CoreStrategy):
     class as inflation of an independent set.
     """
     patterns_needed = set([R_U, C_U])
-    is_valid_extension = staticmethod(one_plus_skewind)
+    is_valid_extension = staticmethod(zero_plus_skewind)
 
 
 class RdCdCoreStrategy(CoreStrategy):
@@ -112,22 +121,22 @@ class RdCdCoreStrategy(CoreStrategy):
     class as inflation of an independent set.
     """
     patterns_needed = set([R_D, C_D])
-    is_valid_extension = staticmethod(one_plus_sumind)
+    is_valid_extension = staticmethod(zero_plus_sumind)
 
 
 class RuCuRdCdCoreStrategy(CoreStrategy):
     patterns_needed = set([R_D, C_D, R_U, C_U])
-    is_valid_extension = staticmethod(one_plus_perm)
+    is_valid_extension = staticmethod(zero_plus_perm)
 
 
 class RuCuCdCoreStrategy(CoreStrategy):
     patterns_needed = set([R_U, C_U, C_D])
-    is_valid_extension = staticmethod(one_plus_skewind)
+    is_valid_extension = staticmethod(zero_plus_skewind)
 
 
 class RdCdCuCoreStrategy(CoreStrategy):
     patterns_needed = set([R_D, C_D, C_U])
-    is_valid_extension = staticmethod(one_plus_sumind)
+    is_valid_extension = staticmethod(zero_plus_sumind)
 
 
 class RdCuCoreStrategy(CoreStrategy):
@@ -135,7 +144,7 @@ class RdCuCoreStrategy(CoreStrategy):
 
     @staticmethod
     def is_valid_extension(patt):
-        return one_plus_skewind(patt) and \
+        return zero_plus_skewind(patt) and \
                 not bstrip(fstrip(patt)).sum_decomposable()
 
 

--- a/permuta/enumeration_strategies/core_strategies.py
+++ b/permuta/enumeration_strategies/core_strategies.py
@@ -1,0 +1,87 @@
+from abc import abstractproperty, abstractstaticmethod
+
+from permuta import Perm
+from permuta.enumeration_strategies.abstract_strategy import \
+        EnumerationStrategy
+
+R_U = Perm((1, 2, 0, 3))
+C_U = Perm((1, 0, 2, 3))
+R_D = Perm((1, 3, 0, 2))
+C_D = Perm((2, 0, 3, 1))
+
+def fstrip(perm):
+    """
+    Remove the leading 1 if the permutation is the sum of 1 + p.
+
+    >>> fstrip(Perm((0, 1, 3, 2)))
+    Perm((0, 2, 1))
+    >>> fstrip(Perm((4, 0, 1, 3, 2)))
+    Perm((4, 0, 1, 3, 2))
+    """
+    if perm[0] == 0:
+        return Perm.from_iterable(perm[1:])
+    else:
+        return perm
+
+def bstrip(perm):
+    """
+    Remove the trailing n if the permutation is the sum of p + 1.
+
+    >>> bstrip(Perm((0, 1, 3, 2)))
+    Perm((0, 1, 3, 2))
+    >>> bstrip(Perm((0, 1, 3, 2, 4)))
+    Perm((0, 1, 3, 2))
+    """
+    if perm[-1] == len(perm)-1:
+        return Perm.from_iterable(perm[:-1])
+    else:
+        return perm
+
+class CoreStrategy(EnumerationStrategy):
+    """
+    Abstract class for a core related strategy.
+    """
+
+    @abstractproperty
+    def PATTERNS_NEEDED():
+        """
+        Return the set of patterns that are needed for the strategy to be
+        useful.
+        """
+        raise NotImplemented
+
+    @abstractstaticmethod
+    def is_valid_extension(patt):
+        """
+        Determine if the pattern satisfies the condition for strategy to apply.
+        """
+        pass
+
+    def applies():
+        b = set(self.basis)
+        extensions_are_valid = all(self.is_valid_extension(patt) for patt in \
+                                   b.difference(self.PATTERNS_NEEDED))
+        return self.PATTERNS_NEEDED.issubset(b) and extensions_are_valid
+
+
+class UpCoreStrategy(CoreStrategy):
+    PATTERNS_NEEDED = set([R_U, C_U])
+
+    def is_valid_extension(patt):
+        return patt[0] == 0 and not fstrip(patt).skew_decomposable()
+
+
+class DownCoreStrategy(CoreStrategy):
+    PATTERNS_NEEDED = set([R_D, C_D])
+
+    def is_valid_extension(patt):
+        return patt[0] == 0 and not fstrip(patt).sum_decomposable()
+
+
+class UpDownCoreStrategy(CoreStrategy):
+    PATTERNS_NEEDED = set([R_D, C_D, R_U, C_U])
+
+    def is_valid_extension(patt):
+        return patt[0] == 0
+
+__all__ = [UpCoreStrategy, DownCoreStrategy]

--- a/permuta/enumeration_strategies/core_strategies.py
+++ b/permuta/enumeration_strategies/core_strategies.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod, abstractproperty, abstractstaticmethod
 
-from permuta import Av, Perm
+from permuta import Av, MeshPatt, Perm
 from permuta.descriptors import Basis
 from permuta.enumeration_strategies.abstract_strategy import \
     EnumerationStrategy
@@ -120,19 +120,9 @@ class RuCuRdCdCoreStrategy(CoreStrategy):
     is_valid_extension = staticmethod(one_plus_perm)
 
 
-class RuCuRdCoreStrategy(CoreStrategy):
-    patterns_needed = set([R_U, C_U, R_D])
-    is_valid_extension = staticmethod(one_plus_skewind)
-
-
 class RuCuCdCoreStrategy(CoreStrategy):
     patterns_needed = set([R_U, C_U, C_D])
     is_valid_extension = staticmethod(one_plus_skewind)
-
-
-class RdCdRuCoreStrategy(CoreStrategy):
-    patterns_needed = set([R_D, C_D, R_U])
-    is_valid_extension = staticmethod(one_plus_sumind)
 
 
 class RdCdCuCoreStrategy(CoreStrategy):
@@ -149,22 +139,31 @@ class RdCuCoreStrategy(CoreStrategy):
                 not bstrip(fstrip(patt)).sum_decomposable()
 
 
-class RuCdCoreStrategy(CoreStrategy):
-    patterns_needed = set([R_U, C_D])
+class Rd2134CoreStrategy(CoreStrategy):
+    patterns_needed = set([R_D, Perm((1, 0, 2, 3))])
 
     @staticmethod
     def is_valid_extension(patt):
-        return one_plus_skewind(patt) and \
-                not bstrip(fstrip(patt)).sum_decomposable()
+        mp1 = MeshPatt(Perm((1, 0)), [(0, 2), (1, 0), (1, 1), (1, 2),
+                                      (2, 1), (2, 2)])
+        mp2 = MeshPatt(Perm((0, 1)), [(0, 0), (0, 1), (0, 2), (1, 0), (1, 1),
+                                      (1, 2), (2, 0), (2, 2)])
+        mp3 = MeshPatt(Perm((1, 0)), [(0, 1), (0, 2), (1, 1), (1, 2), (2, 1),
+                                      (2, 2)])
+        return (not patt.skew_decomposable() and
+                not mp1.contained_in(patt) and
+                not mp2.contained_in(patt) and
+                (mp3.contained_in(patt) or
+                 (patt[len(patt)-1] == len(patt)-1 and
+                  not bstrip(patt).skew_decomposable())))
+
 
 core_strategies = [
     RuCuCoreStrategy,
     RdCdCoreStrategy,
     RuCuRdCdCoreStrategy,
-    RuCuRdCoreStrategy,
     RuCuCdCoreStrategy,
-    RdCdRuCoreStrategy,
     RdCdCuCoreStrategy,
     RdCuCoreStrategy,
-    RuCdCoreStrategy,
+    Rd2134CoreStrategy,
 ]

--- a/permuta/enumeration_strategies/core_strategies.py
+++ b/permuta/enumeration_strategies/core_strategies.py
@@ -50,6 +50,7 @@ class CoreStrategy(EnumerationStrategyWithSymmetry):
 
 # Tool functions
 
+
 def fstrip(perm):
     """
     Remove the leading 1 if the permutation is the sum of 1 + p.
@@ -173,8 +174,9 @@ class Rd2134CoreStrategy(CoreStrategy):
     def is_valid_extension(patt):
         mp = MeshPatt(Perm((1, 0)), [(0, 1), (0, 2), (1, 0), (1, 1), (1, 2),
                                      (2, 1), (2, 2)])
+        last_comp = last_sum_component(fstrip(patt))
         return (patt[0] == 0 and fstrip(patt).avoids(mp) and
-                last_sum_component(fstrip(patt)) not in Av([Perm((0, 1))]))
+                (last_comp not in Av([Perm((0, 1))]) or len(last_comp) == 1))
 
 
 class Ru2143CoreStrategy(CoreStrategy):

--- a/permuta/enumeration_strategies/core_strategies.py
+++ b/permuta/enumeration_strategies/core_strategies.py
@@ -40,7 +40,7 @@ class CoreStrategy(EnumerationStrategyWithSymmetry):
 
         - `b`: a set of permutations.
         """
-        assert isinstance(b, set)
+        assert isinstance(b, frozenset)
         perm_class = Av(b)
         patterns_are_contained = all(p not in perm_class for p in
                                      self.patterns_needed)
@@ -111,7 +111,7 @@ class RuCuCoreStrategy(CoreStrategy):
     This strategies uses independent set of the up-core graph to enumerate a
     class as inflation of an independent set.
     """
-    patterns_needed = set([R_U, C_U])
+    patterns_needed = frozenset([R_U, C_U])
     is_valid_extension = staticmethod(zero_plus_skewind)
 
 
@@ -120,27 +120,27 @@ class RdCdCoreStrategy(CoreStrategy):
     This strategies uses independent set of the down-core graph to enumerate a
     class as inflation of an independent set.
     """
-    patterns_needed = set([R_D, C_D])
+    patterns_needed = frozenset([R_D, C_D])
     is_valid_extension = staticmethod(zero_plus_sumind)
 
 
 class RuCuRdCdCoreStrategy(CoreStrategy):
-    patterns_needed = set([R_D, C_D, R_U, C_U])
+    patterns_needed = frozenset([R_D, C_D, R_U, C_U])
     is_valid_extension = staticmethod(zero_plus_perm)
 
 
 class RuCuCdCoreStrategy(CoreStrategy):
-    patterns_needed = set([R_U, C_U, C_D])
+    patterns_needed = frozenset([R_U, C_U, C_D])
     is_valid_extension = staticmethod(zero_plus_skewind)
 
 
 class RdCdCuCoreStrategy(CoreStrategy):
-    patterns_needed = set([R_D, C_D, C_U])
+    patterns_needed = frozenset([R_D, C_D, C_U])
     is_valid_extension = staticmethod(zero_plus_sumind)
 
 
 class RdCuCoreStrategy(CoreStrategy):
-    patterns_needed = set([R_D, C_U])
+    patterns_needed = frozenset([R_D, C_U])
 
     @staticmethod
     def is_valid_extension(patt):
@@ -149,7 +149,7 @@ class RdCuCoreStrategy(CoreStrategy):
 
 
 class Rd2134CoreStrategy(CoreStrategy):
-    patterns_needed = set([R_D, Perm((1, 0, 2, 3))])
+    patterns_needed = frozenset([R_D, Perm((1, 0, 2, 3))])
 
     @staticmethod
     def is_valid_extension(patt):

--- a/permuta/enumeration_strategies/core_strategies.py
+++ b/permuta/enumeration_strategies/core_strategies.py
@@ -35,9 +35,12 @@ class CoreStrategy(EnumerationStrategy):
 
     def applies(self):
         b = set(self.basis)
+        perm_class = Av(b)
+        patterns_are_contained = all(p not in perm_class for p in
+                                     self.patterns_needed)
         extensions_are_valid = all(self.is_valid_extension(patt) for patt in
                                    b.difference(self.patterns_needed))
-        return self.patterns_needed.issubset(b) and extensions_are_valid
+        return patterns_are_contained and extensions_are_valid
 
 
 # Tool functions

--- a/permuta/enumeration_strategies/core_strategies.py
+++ b/permuta/enumeration_strategies/core_strategies.py
@@ -48,6 +48,17 @@ class CoreStrategy(EnumerationStrategyWithSymmetry):
                                    b.difference(self.patterns_needed))
         return patterns_are_contained and extensions_are_valid
 
+    @classmethod
+    def reference(cls):
+        return ('Enumeration of Permutation Classes and Weighted Labelled '
+                'Independent Sets: Corollary {}').format(cls.corr_number)
+
+    @property
+    @staticmethod
+    def corr_number():
+        """The number of the corollary in the that gives this strategy."""
+        raise NotImplementedError
+
 # Tool functions
 
 
@@ -129,6 +140,7 @@ class RuCuCoreStrategy(CoreStrategy):
     """
     patterns_needed = frozenset([R_U, C_U])
     is_valid_extension = staticmethod(zero_plus_skewind)
+    corr_number = '4.3'
 
 
 class RdCdCoreStrategy(CoreStrategy):
@@ -138,20 +150,24 @@ class RdCdCoreStrategy(CoreStrategy):
     """
     patterns_needed = frozenset([R_D, C_D])
     is_valid_extension = staticmethod(zero_plus_sumind)
+    corr_number = '4.6'
 
 
 class RuCuRdCdCoreStrategy(CoreStrategy):
     patterns_needed = frozenset([R_D, C_D, R_U, C_U])
     is_valid_extension = staticmethod(zero_plus_perm)
+    corr_number = '5.4'
 
 
 class RuCuCdCoreStrategy(CoreStrategy):
     patterns_needed = frozenset([R_U, C_U, C_D])
     is_valid_extension = staticmethod(zero_plus_skewind)
+    corr_number = '6.3'
 
 
 class RdCdCuCoreStrategy(CoreStrategy):
     patterns_needed = frozenset([R_D, C_D, C_U])
+    corr_number = '7.4'
 
     @staticmethod
     def is_valid_extension(patt):
@@ -160,6 +176,7 @@ class RdCdCuCoreStrategy(CoreStrategy):
 
 class RdCuCoreStrategy(CoreStrategy):
     patterns_needed = frozenset([R_D, C_U])
+    corr_number = '8.3'
 
     @staticmethod
     def is_valid_extension(patt):
@@ -169,6 +186,7 @@ class RdCuCoreStrategy(CoreStrategy):
 
 class Rd2134CoreStrategy(CoreStrategy):
     patterns_needed = frozenset([R_D, Perm((1, 0, 2, 3))])
+    corr_number = '9.5'
 
     @staticmethod
     def is_valid_extension(patt):
@@ -181,6 +199,7 @@ class Rd2134CoreStrategy(CoreStrategy):
 
 class Ru2143CoreStrategy(CoreStrategy):
     patterns_needed = frozenset([R_U, Perm((1, 0, 3, 2))])
+    corr_number = '10.5'
 
     @staticmethod
     def is_valid_extension(patt):

--- a/permuta/enumeration_strategies/insertion_encodable.py
+++ b/permuta/enumeration_strategies/insertion_encodable.py
@@ -1,0 +1,13 @@
+"""
+Enumeration strategies related to the insertion encoding.
+"""
+
+from permuta.enumeration_strategies.abstract_strategy import \
+    EnumerationStrategy
+from permuta.permutils.insertion_encodable import is_insertion_encodable
+
+
+class InsertionEncodingStrategy(EnumerationStrategy):
+
+    def applies(self):
+        return is_insertion_encodable(self.basis)

--- a/permuta/enumeration_strategies/insertion_encodable.py
+++ b/permuta/enumeration_strategies/insertion_encodable.py
@@ -3,11 +3,12 @@ Enumeration strategies related to the insertion encoding.
 """
 
 from permuta.enumeration_strategies.abstract_strategy import \
-    EnumerationStrategy
-from permuta.permutils.insertion_encodable import is_insertion_encodable
+    EnumerationStrategyWithSymmetry
+from permuta.permutils.insertion_encodable import \
+    is_insertion_encodable_maximum
 
 
-class InsertionEncodingStrategy(EnumerationStrategy):
+class InsertionEncodingStrategy(EnumerationStrategyWithSymmetry):
 
-    def applies(self):
-        return is_insertion_encodable(self.basis)
+    def _applies_to_symmetry(self, b):
+        return is_insertion_encodable_maximum(b)

--- a/tests/enumeration_strategies/test_core_strategies.py
+++ b/tests/enumeration_strategies/test_core_strategies.py
@@ -3,18 +3,32 @@ from permuta import Perm
 from permuta.enumeration_strategies.core_strategies import (fstrip, bstrip,
                                                             zero_plus_perm,
                                                             zero_plus_sumind,
-                                                            zero_plus_skewind)
-from permuta.enumeration_strategies.core_strategies import RuCuCoreStrategy
+                                                            zero_plus_skewind,
+                                                            last_sum_component,
+                                                            last_skew_component)
+from permuta.enumeration_strategies.core_strategies import (RuCuCoreStrategy,
+                                                            RdCdCoreStrategy,
+                                                            RuCuRdCdCoreStrategy,
+                                                            RuCuCdCoreStrategy,
+                                                            RdCdCuCoreStrategy,
+                                                            RdCuCoreStrategy,
+                                                            Rd2134CoreStrategy,
+                                                            Ru2143CoreStrategy)
 
 ru = Perm((1,2,0,3))
 cu = Perm((2,0,1,3))
 rd = Perm((1,3,0,2))
 cd = Perm((2,0,3,1))
+p2134 = Perm((1,0,2,3))
+p2143 = Perm((1,0,3,2))
 
 class TestRuCu():
     def test_applies(self):
         assert RuCuCoreStrategy([ru, cu])
         assert RuCuCoreStrategy([ru, cu, Perm((0,1,2,3))])
+        assert not RuCuCoreStrategy([ru, Perm((0,1,2,3))]).applies()
+        assert not RuCuCoreStrategy([ru, cu, Perm((1,4,0,2,3))]).applies()
+        assert RuCuCoreStrategy([ru, cu, Perm((0,1,2,3,4))]).applies()
 
     def test_applies_to_a_symmetry(self):
         assert RuCuCoreStrategy([Perm([0,2,3,1]), Perm([0,3,1,2])]).applies()
@@ -28,6 +42,134 @@ class TestRuCu():
         assert not RuCuCoreStrategy(b2)._applies_to_symmetry(b2)
         b3 = frozenset([ru, cu])
         assert RuCuCoreStrategy(b3)._applies_to_symmetry(b3)
+
+
+class TestRdCd():
+
+    def test_applies(self):
+        assert not RdCdCoreStrategy([rd, cd, Perm((0,1,2,3,4))]).applies()
+        assert not RdCdCoreStrategy([rd, Perm((0,3,2,1))]).applies()
+        assert RdCdCoreStrategy([rd, cd]).applies()
+        assert RdCdCoreStrategy([rd, cd, Perm((0,4,1,2,3))]).applies()
+
+    def test_applies_to_a_symmetry(self):
+        assert RdCdCoreStrategy([Perm((1,3,0,2)), Perm((2,0,3,1))]).applies()
+
+    def test_specific_symmetry(self):
+        b1 = frozenset([Perm((1,3,0,2)), Perm((2,0,3,1))])
+        assert RdCdCoreStrategy(b1)._applies_to_symmetry(b1)
+        b2 = frozenset([rd, cd])
+        assert RdCdCoreStrategy(b2)._applies_to_symmetry(b2)
+
+
+class TestRuCuRdCd():
+
+    def test_applies(self):
+        assert not RuCuRdCdCoreStrategy([rd, cd]).applies()
+        assert not RuCuRdCdCoreStrategy([rd, cd, ru, Perm((0,3,2,1))]).applies()
+        assert RuCuRdCdCoreStrategy([rd, cd, ru, cu]).applies()
+        assert RuCuRdCdCoreStrategy([rd, cd, ru, cu, Perm((0,1,2,3))]).applies()
+
+    def test_applies_to_a_symmetry(self):
+        assert RuCuRdCdCoreStrategy([Perm((0,2,3,1)), Perm((0,3,1,2)),
+                                     Perm((1,3,0,2)), Perm((2,0,3,1))]).applies()
+
+    def test_specific_symmetry(self):
+        b1 = frozenset([Perm((0,2,3,1)), Perm((0,3,1,2)),
+                        Perm((1,3,0,2)), Perm((2,0,3,1))])
+        assert not RuCuRdCdCoreStrategy(b1)._applies_to_symmetry(b1)
+        b2 = frozenset([rd, cd, cu, ru])
+        assert RuCuRdCdCoreStrategy(b2)._applies_to_symmetry(b2)
+
+
+class TestRuCuCd():
+
+    def test_applies(self):
+        assert RuCuCdCoreStrategy([cd, ru, cu]).applies()
+        assert not RuCuCdCoreStrategy([rd, cd]).applies()
+        assert not RuCuCdCoreStrategy([rd, cd, ru, Perm((0,3,2,1))]).applies()
+        assert RuCuCdCoreStrategy([ru, cu, cd, Perm((0,1,2,3))]).applies()
+
+    def test_applies_to_a_symmetry(self):
+        assert RuCuCdCoreStrategy([Perm((0,2,3,1)), Perm((0,3,1,2)),
+                                     Perm((1,3,0,2))]).applies()
+        assert RuCuCdCoreStrategy([Perm((0,2,3,1)), Perm((0,3,1,2)),
+                                     Perm((1,3,0,2)), Perm((0,1,2,3))]).applies()
+
+
+class TestRdCdCu():
+    def test_applies(self):
+        assert RdCdCuCoreStrategy([rd, cd, cu]).applies()
+        assert not RdCdCuCoreStrategy([rd, cd]).applies()
+        assert not RdCdCuCoreStrategy([rd, cd, cu, Perm((0,1,2,3))]).applies()
+        assert RdCdCuCoreStrategy([rd, cd, cu, Perm((0,2,1,3))]).applies()
+        assert RdCdCuCoreStrategy([rd, cd, cu, Perm((0,3,2,1))]).applies()
+
+    def test_applies_to_a_symmetry(self):
+        assert RdCdCuCoreStrategy([rd, cd, ru]).applies()
+
+    def test_is_valid_extension(self):
+        assert RdCdCuCoreStrategy.is_valid_extension(Perm((0,2,1,3)))
+        assert not RdCdCuCoreStrategy.is_valid_extension(Perm((1,2,0,3)))
+
+
+class TestRdCu():
+    def test_applies(self):
+        assert RdCuCoreStrategy([rd, cu]).applies()
+        assert not RdCuCoreStrategy([rd, cd]).applies()
+        assert not RdCuCoreStrategy([rd, cu, Perm((0,1,2,3))]).applies()
+        assert not RdCuCoreStrategy([rd, cu, Perm((0,3,2,1))]).applies()
+        assert RdCuCoreStrategy([rd, cu, Perm((0,2,1,3))]).applies()
+        assert RdCuCoreStrategy([rd, cu, Perm((0,3,1,2,4))]).applies()
+
+    def test_applies_to_a_symmetry(self):
+        assert RdCuCoreStrategy([ru, cd]).applies()
+
+    def test_is_valid_extension(self):
+        assert RdCuCoreStrategy.is_valid_extension(Perm((0,2,1,3)))
+        assert not RdCuCoreStrategy.is_valid_extension(Perm((1,2,0,3)))
+
+
+class TestRd2134():
+    def test_applies(self):
+        assert Rd2134CoreStrategy([rd, p2134]).applies()
+        assert not Rd2134CoreStrategy([rd, cu]).applies()
+        assert not Rd2134CoreStrategy([rd, p2134, Perm((0,4,3,1,2))]).applies()
+        assert not Rd2134CoreStrategy([rd, cu, Perm((0,1,2,3))]).applies()
+        assert Rd2134CoreStrategy([rd, p2134, Perm((0,3,4,2,1))]).applies()
+        assert Rd2134CoreStrategy([rd, p2134, Perm((0,3,2,4,1))]).applies()
+
+    def test_applies_to_a_symmetry(self):
+        assert Rd2134CoreStrategy([cd, p2134]).applies()
+        assert Rd2134CoreStrategy([Perm.from_string('0132'),
+                                   Perm.from_string('1302'),
+                                   Perm.from_string('32014')]).applies()
+
+    def test_is_valid_extension(self):
+        assert Rd2134CoreStrategy.is_valid_extension(Perm((0,3,4,2,1)))
+        assert not Rd2134CoreStrategy.is_valid_extension(Perm((0,4,3,1,2)))
+        assert not Rd2134CoreStrategy.is_valid_extension(Perm((0,1,2,3)))
+
+
+class TestRu2143():
+    def test_applies(self):
+        assert Ru2143CoreStrategy([ru, p2143]).applies()
+        assert not Ru2143CoreStrategy([ru]).applies()
+        assert not Ru2143CoreStrategy([ru, p2143, Perm((0,2,1,3,4))]).applies()
+        assert not Ru2143CoreStrategy([ru, p2143, Perm((0,4,3,1,2))]).applies()
+        assert Ru2143CoreStrategy([ru, p2143, Perm((0,2,4,1,3))]).applies()
+        assert Ru2143CoreStrategy([ru, p2143, Perm((0,1,2,4,3))]).applies()
+
+    def test_applies_to_a_symmetry(self):
+        assert Ru2143CoreStrategy([cu, p2143]).applies()
+        assert Ru2143CoreStrategy([Perm.from_string('0231'),
+                                   Perm.from_string('1032'),
+                                   Perm.from_string('03124')]).applies()
+
+    def test_is_valid_extension(self):
+        assert Ru2143CoreStrategy.is_valid_extension(Perm((0,2,4,1,3)))
+        assert not Ru2143CoreStrategy.is_valid_extension(Perm((0,2,1,3,4)))
+        assert not Ru2143CoreStrategy.is_valid_extension(Perm((0,4,3,1,2)))
 
 # Test for tools functions
 
@@ -56,3 +198,15 @@ def test_zero_plus_sumind():
     assert zero_plus_sumind(Perm((0,3,1,2)))
     assert not zero_plus_sumind(Perm((0,1,3,2)))
     assert not zero_plus_sumind(Perm((1,3,0,2)))
+
+
+def test_last_sum_component():
+    assert last_sum_component(Perm((0,1,2,4,3))) == Perm((1, 0))
+    assert last_sum_component(Perm((0,1,2,3))) == Perm((0,))
+    assert last_sum_component(Perm((3,2,1,0))) == Perm((3, 2, 1, 0))
+
+
+def test_last_skew_component():
+    last_skew_component(Perm((2,4,3,0,1))) == Perm((0, 1))
+    last_skew_component(Perm((0,1,2,3))) == Perm((0, 1, 2, 3))
+    last_skew_component(Perm((3,2,1,0))) == Perm((0,))

--- a/tests/enumeration_strategies/test_core_strategies.py
+++ b/tests/enumeration_strategies/test_core_strategies.py
@@ -45,6 +45,13 @@ class TestRuCu():
         b3 = frozenset([ru, cu])
         assert RuCuCoreStrategy(b3)._applies_to_symmetry(b3)
 
+    def test_reference(self):
+        print(RuCuCoreStrategy.reference())
+        assert RuCuCoreStrategy.reference() == (
+            'Enumeration of Permutation '
+            'Classes and Weighted Labelled Independent Sets: '
+            'Corollary 4.3')
+
 
 class TestRdCd():
 

--- a/tests/enumeration_strategies/test_core_strategies.py
+++ b/tests/enumeration_strategies/test_core_strategies.py
@@ -29,6 +29,8 @@ class TestRuCu():
         assert not RuCuCoreStrategy([ru, Perm((0,1,2,3))]).applies()
         assert not RuCuCoreStrategy([ru, cu, Perm((1,4,0,2,3))]).applies()
         assert RuCuCoreStrategy([ru, cu, Perm((0,1,2,3,4))]).applies()
+        assert RuCuCoreStrategy([ru, cu, Perm((0,2,4,1,3)),
+                                 Perm((0,1,3,2,4))]).applies()
 
     def test_applies_to_a_symmetry(self):
         assert RuCuCoreStrategy([Perm([0,2,3,1]), Perm([0,3,1,2])]).applies()
@@ -91,10 +93,14 @@ class TestRuCuCd():
         assert RuCuCdCoreStrategy([ru, cu, cd, Perm((0,1,2,3))]).applies()
 
     def test_applies_to_a_symmetry(self):
+        assert RuCuCdCoreStrategy([ru, cu, rd]).applies()
+        assert RuCuCdCoreStrategy([ru, cu, rd, Perm((0,2,1,3))]).applies()
         assert RuCuCdCoreStrategy([Perm((0,2,3,1)), Perm((0,3,1,2)),
                                      Perm((1,3,0,2))]).applies()
         assert RuCuCdCoreStrategy([Perm((0,2,3,1)), Perm((0,3,1,2)),
                                      Perm((1,3,0,2)), Perm((0,1,2,3))]).applies()
+        # 123 implies the avoidance of ru and cu
+        assert RuCuCdCoreStrategy([rd, Perm((0,1,2))]).applies()
 
 
 class TestRdCdCu():
@@ -107,6 +113,8 @@ class TestRdCdCu():
 
     def test_applies_to_a_symmetry(self):
         assert RdCdCuCoreStrategy([rd, cd, ru]).applies()
+        # Symmetry and adding pattern
+        assert RdCdCuCoreStrategy([Perm((1,0,2)), Perm((0,3,1,2))]).applies()
 
     def test_is_valid_extension(self):
         assert RdCdCuCoreStrategy.is_valid_extension(Perm((0,2,1,3)))
@@ -138,6 +146,9 @@ class TestRd2134():
         assert not Rd2134CoreStrategy([rd, cu, Perm((0,1,2,3))]).applies()
         assert Rd2134CoreStrategy([rd, p2134, Perm((0,3,4,2,1))]).applies()
         assert Rd2134CoreStrategy([rd, p2134, Perm((0,3,2,4,1))]).applies()
+        assert Rd2134CoreStrategy([rd, p2134, Perm((0,1,2,3))]).applies()
+        assert Rd2134CoreStrategy([rd, p2134, Perm((0,2,1,3)),
+                                   Perm((0,1,4,2,3))]).applies()
 
     def test_applies_to_a_symmetry(self):
         assert Rd2134CoreStrategy([cd, p2134]).applies()
@@ -148,7 +159,8 @@ class TestRd2134():
     def test_is_valid_extension(self):
         assert Rd2134CoreStrategy.is_valid_extension(Perm((0,3,4,2,1)))
         assert not Rd2134CoreStrategy.is_valid_extension(Perm((0,4,3,1,2)))
-        assert not Rd2134CoreStrategy.is_valid_extension(Perm((0,1,2,3)))
+        assert Rd2134CoreStrategy.is_valid_extension(Perm((0,1,2,3)))
+        assert not Rd2134CoreStrategy.is_valid_extension(Perm((0,1,2,4,3)))
 
 
 class TestRu2143():

--- a/tests/enumeration_strategies/test_core_strategies.py
+++ b/tests/enumeration_strategies/test_core_strategies.py
@@ -22,11 +22,11 @@ class TestRuCu():
                                  Perm([0,1,2,3])]).applies()
 
     def test_specific_symmetry(self):
-        b1 = set([ru, cu, Perm((3,0,1,2))])
+        b1 = frozenset([ru, cu, Perm((3,0,1,2))])
         assert not RuCuCoreStrategy(b1)._applies_to_symmetry(b1)
-        b2 = set([ru, cu, Perm((0,3,2,1))])
+        b2 = frozenset([ru, cu, Perm((0,3,2,1))])
         assert not RuCuCoreStrategy(b2)._applies_to_symmetry(b2)
-        b3 = set([ru, cu])
+        b3 = frozenset([ru, cu])
         assert RuCuCoreStrategy(b3)._applies_to_symmetry(b3)
 
 # Test for tools functions

--- a/tests/enumeration_strategies/test_core_strategies.py
+++ b/tests/enumeration_strategies/test_core_strategies.py
@@ -1,0 +1,58 @@
+from permuta import Perm
+
+from permuta.enumeration_strategies.core_strategies import (fstrip, bstrip,
+                                                            zero_plus_perm,
+                                                            zero_plus_sumind,
+                                                            zero_plus_skewind)
+from permuta.enumeration_strategies.core_strategies import RuCuCoreStrategy
+
+ru = Perm((1,2,0,3))
+cu = Perm((2,0,1,3))
+rd = Perm((1,3,0,2))
+cd = Perm((2,0,3,1))
+
+class TestRuCu():
+    def test_applies(self):
+        assert RuCuCoreStrategy([ru, cu])
+        assert RuCuCoreStrategy([ru, cu, Perm((0,1,2,3))])
+
+    def test_applies_to_a_symmetry(self):
+        assert RuCuCoreStrategy([Perm([0,2,3,1]), Perm([0,3,1,2])]).applies()
+        assert RuCuCoreStrategy([Perm([0,2,3,1]), Perm([0,3,1,2]),
+                                 Perm([0,1,2,3])]).applies()
+
+    def test_specific_symmetry(self):
+        b1 = set([ru, cu, Perm((3,0,1,2))])
+        assert not RuCuCoreStrategy(b1)._applies_to_symmetry(b1)
+        b2 = set([ru, cu, Perm((0,3,2,1))])
+        assert not RuCuCoreStrategy(b2)._applies_to_symmetry(b2)
+        b3 = set([ru, cu])
+        assert RuCuCoreStrategy(b3)._applies_to_symmetry(b3)
+
+# Test for tools functions
+
+def test_fstrip():
+    assert fstrip(Perm((0, 1, 3, 2))) == Perm((0, 2, 1))
+    assert fstrip(Perm((4, 0, 1, 3, 2))) == Perm((4, 0, 1, 3, 2))
+
+
+def test_bstrip():
+    assert bstrip(Perm((0, 1, 3, 2))) == Perm((0, 1, 3, 2))
+    assert bstrip(Perm((0, 1, 3, 2, 4))) == Perm((0, 1, 3, 2))
+
+
+def test_zero_plus_perm():
+    assert zero_plus_perm(Perm((0,1,2)))
+    assert not zero_plus_perm(Perm((3,0,1,2)))
+
+
+def test_zero_plus_skewind():
+    assert zero_plus_skewind(Perm((0,1,3,2)))
+    assert not zero_plus_skewind(Perm((0,3,1,2)))
+    assert not zero_plus_skewind(Perm((1,3,0,2)))
+
+
+def test_zero_plus_sumind():
+    assert zero_plus_sumind(Perm((0,3,1,2)))
+    assert not zero_plus_sumind(Perm((0,1,3,2)))
+    assert not zero_plus_sumind(Perm((1,3,0,2)))

--- a/tests/test_enumeration_strategies.py
+++ b/tests/test_enumeration_strategies.py
@@ -2,9 +2,15 @@ from permuta import Av, Perm
 from permuta.descriptors import Basis
 from permuta.enumeration_strategies.insertion_encodable import \
         InsertionEncodingStrategy
-from permuta.enumeration_strategies import all_enumeration_strategies
+from permuta.enumeration_strategies import (all_enumeration_strategies,
+                                            find_strategies)
 from permuta.enumeration_strategies.core_strategies import (RuCuCoreStrategy,
                                                             RdCdCoreStrategy)
+
+ru = Perm((1,2,0,3))
+cu = Perm((2,0,1,3))
+rd = Perm((1,3,0,2))
+cd = Perm((2,0,3,1))
 
 def test_init_strategy():
     b1 = [Perm((0,1,2))]
@@ -19,11 +25,6 @@ def test_insertion_encoding():
     strat = InsertionEncodingStrategy([Perm((0,2,1,3))])
     assert not strat.applies()
 
-ru = Perm((1,2,0,3))
-cu = Perm((2,0,1,3))
-rd = Perm((1,3,0,2))
-cd = Perm((2,0,3,1))
-
 def test_RuCu():
     assert not RuCuCoreStrategy([ru, cu, Perm((1,4,0,2,3))]).applies()
     assert not RuCuCoreStrategy([ru, Perm((0,1,2,3))]).applies()
@@ -35,3 +36,14 @@ def test_RdCd():
     assert not RdCdCoreStrategy([rd, Perm((0,3,2,1))]).applies()
     assert RdCdCoreStrategy([rd, cd]).applies()
     assert RdCdCoreStrategy([rd, cd, Perm((0,4,1,2,3))]).applies()
+
+def test_find_strategies():
+    b1 = [Perm((0,1,2))]
+    b2 = Basis([Perm((0,1,2,3)), Perm((2,0,1))])
+    assert len(find_strategies(b1)) == 0
+    assert len(find_strategies(b2)) > 0
+    assert any(isinstance(s, InsertionEncodingStrategy) for s in
+               find_strategies(b2))
+    assert any(isinstance(s, RuCuCoreStrategy) for s in
+               find_strategies([ru, cu]))
+

--- a/tests/test_enumeration_strategies.py
+++ b/tests/test_enumeration_strategies.py
@@ -38,7 +38,7 @@ def test_RdCd():
     assert RdCdCoreStrategy([rd, cd, Perm((0,4,1,2,3))]).applies()
 
 def test_find_strategies():
-    b1 = [Perm((0,1,2))]
+    b1 = [Perm((0,1,2,3,4))]
     b2 = Basis([Perm((0,1,2,3)), Perm((2,0,1))])
     assert len(find_strategies(b1, long_runnning=True)) == 0
     assert len(find_strategies(b1, long_runnning=False)) == 0

--- a/tests/test_enumeration_strategies.py
+++ b/tests/test_enumeration_strategies.py
@@ -1,9 +1,37 @@
-from permuta import Perm, Av
+from permuta import Av, Perm
+from permuta.descriptors import Basis
 from permuta.enumeration_strategies.insertion_encodable import \
         InsertionEncodingStrategy
+from permuta.enumeration_strategies import all_enumeration_strategies
+from permuta.enumeration_strategies.core_strategies import (RuCuCoreStrategy,
+                                                            RdCdCoreStrategy)
+
+def test_init_strategy():
+    b1 = [Perm((0,1,2))]
+    b2 = Basis([Perm((0,1,2,3)), Perm((2,0,1))])
+    for Strat in all_enumeration_strategies:
+        Strat(b1).applies()
+        Strat(b2).applies()
 
 def test_insertion_encoding():
     strat = InsertionEncodingStrategy([Perm((0,1,2)), Perm((2,0,1))])
     assert strat.applies()
     strat = InsertionEncodingStrategy([Perm((0,2,1,3))])
     assert not strat.applies()
+
+ru = Perm((1,2,0,3))
+cu = Perm((2,0,1,3))
+rd = Perm((1,3,0,2))
+cd = Perm((2,0,3,1))
+
+def test_RuCu():
+    assert not RuCuCoreStrategy([ru, cu, Perm((1,4,0,2,3))]).applies()
+    assert not RuCuCoreStrategy([ru, Perm((0,1,2,3))]).applies()
+    assert RuCuCoreStrategy([ru, cu]).applies()
+    assert RuCuCoreStrategy([ru, cu, Perm((0,1,2,3,4))]).applies()
+
+def test_RdCd():
+    assert not RdCdCoreStrategy([rd, cd, Perm((0,1,2,3,4))]).applies()
+    assert not RdCdCoreStrategy([rd, Perm((0,3,2,1))]).applies()
+    assert RdCdCoreStrategy([rd, cd]).applies()
+    assert RdCdCoreStrategy([rd, cd, Perm((0,4,1,2,3))]).applies()

--- a/tests/test_enumeration_strategies.py
+++ b/tests/test_enumeration_strategies.py
@@ -1,0 +1,9 @@
+from permuta import Perm, Av
+from permuta.enumeration_strategies.insertion_encodable import \
+        InsertionEncodingStrategy
+
+def test_insertion_encoding():
+    strat = InsertionEncodingStrategy([Perm((0,1,2)), Perm((2,0,1))])
+    assert strat.applies()
+    strat = InsertionEncodingStrategy([Perm((0,2,1,3))])
+    assert not strat.applies()

--- a/tests/test_enumeration_strategies.py
+++ b/tests/test_enumeration_strategies.py
@@ -40,7 +40,8 @@ def test_RdCd():
 def test_find_strategies():
     b1 = [Perm((0,1,2))]
     b2 = Basis([Perm((0,1,2,3)), Perm((2,0,1))])
-    assert len(find_strategies(b1)) == 0
+    assert len(find_strategies(b1, long_runnning=True)) == 0
+    assert len(find_strategies(b1, long_runnning=False)) == 0
     assert len(find_strategies(b2)) > 0
     assert any(isinstance(s, InsertionEncodingStrategy) for s in
                find_strategies(b2))


### PR DESCRIPTION
The purpose of this pull request is to build in `permuta` a tool to guide your choice of strategy to enumerate a permutation class.

The idea is the following, you have an abstract class `EnumerationStrategy` with a basis attribute and the abstract method `applies` that determine if the strategy applies to this basis. Every Enumeration strategy inherit from this class.

## ToDo

- [x] Implement the abstract class `enumeration_strategy`
- [x] Add insertion encodable strategy
- [ ] Add finitely (or small growth rate) many simple strategy
- [x] Add the core strategies (in progress)
- [x] Add the cyclic shift strategy
- [x] Integrate references to the literature for the strategies
- [x] Find a way to check if a strategy can be useful for a symmetry of the basis

## Questions

1. Where does the `Basis.enumeration_strategies()` method should go? I'm completely loss in all the descriptor/metaclass mess.
2. How should we attached the reference to the strategy? I thought of a string that's a link to the paper as a class attribute.
3. I thought of a class method for the strategy that return a string that tell you how to use the strategy to solve the basis. That would give lot of flexibility on the type of strategies we can use. Then for strategy when it is doable we also add a function that a more explicit output (for example the functional equation for the core thing). Any idea name for those function?