### PR TITLE
MeshBasis of a mix of Perms and MeshPatts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Allow for a mix of permutation and mesh patterns in MeshBasis
 
 ## [1.2.0] - 2019-09-05
 ### Added

--- a/permuta/descriptors/basis.py
+++ b/permuta/descriptors/basis.py
@@ -110,7 +110,13 @@ class Basis(AbstractBasis):
 
 
 class MeshBasis(AbstractBasis):
-    ALLOWED_BASIS_ELEMENT_TYPES = (Perm, MeshPatt)
+    ALLOWED_BASIS_ELEMENT_TYPES = (MeshPatt,)
+
+    def __new__(cls, patts):
+        return super().__new__(cls, {
+            patt if isinstance(patt, MeshPatt) else MeshPatt(patt, [])
+            for patt in patts
+        })
 
 
 def detect_basis_cls(basis):

--- a/tests/_perm_set/unbounded/described/avoiding/test_avoiding_generic.py
+++ b/tests/_perm_set/unbounded/described/avoiding/test_avoiding_generic.py
@@ -19,18 +19,6 @@ def test_iter_getitem_same_principal_classes():
                 if index > maximum:
                     break
 
-def test_basis_with_empty_perm():
-    basis = Basis([Perm(), Perm((0,))])
-    assert basis == Basis(Perm())
-
-def test_meshbasis_with_empty_meshpatt():
-    meshbasis = MeshBasis([MeshPatt(), MeshPatt(Perm((0,)), ())])
-    assert meshbasis == MeshBasis(MeshPatt())
-
-def test_meshbasis_with_empty_perm():
-    meshbasis = MeshBasis([MeshPatt(), Perm()])
-    assert meshbasis == MeshBasis(Perm())
-
 def test_avoiding_generic_principal_classes():
     ts = [
         ([[0, 1]], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
@@ -96,8 +84,8 @@ def test_avoiding_generic_mesh_patterns():
     p = Perm((2, 0, 1))
     shading = ((2, 0), (2, 1), (2, 2), (2, 3))
     mps = [MeshPatt(p, shading)]
-    basis = MeshBasis(mps)
-    avoiding_generic_basis = AvoidingGeneric(basis)
+    meshbasis = MeshBasis(mps)
+    avoiding_generic_basis = AvoidingGeneric(meshbasis)
     enum = [1, 1, 2, 5, 15, 52, 203, 877]  # Bell numbers
 
     for (n, cnt) in enumerate(enum):
@@ -115,7 +103,7 @@ def test_avoiding_generic_mesh_patterns():
 
     mx = len(enum) - 1
     cnt = [0 for _ in range(mx + 1)]
-    for perm in AvoidingGeneric(basis):
+    for perm in AvoidingGeneric(meshbasis):
         if len(perm) > mx:
             break
         assert perm.avoids(*mps)

--- a/tests/descriptors/test_basis.py
+++ b/tests/descriptors/test_basis.py
@@ -1,7 +1,6 @@
 import pytest
 
-from permuta import MeshPatt
-from permuta import Perm
+from permuta import MeshPatt, Perm
 from permuta.descriptors.basis import Basis, MeshBasis, detect_basis_cls
 
 
@@ -32,16 +31,51 @@ def test_detect_basis_cls():
     assert detect_basis_cls(Basis(perm_list)) == Basis
 
 
-def test_detect_mesh_basis_cls():
+def test_detect_meshbasis_cls():
     p1 = Perm((0, 2, 1))
     p2 = Perm((2, 0, 1))
     shading = ((2, 0), (2, 1), (2, 2), (2, 3))
     mp1 = MeshPatt(p1, shading)
     mp2 = MeshPatt(p2, shading)
     meshpatt_list = [mp1, mp2]
+    mixed_patt_list = [p1, mp2]
 
     assert detect_basis_cls(mp1) == MeshBasis
     assert detect_basis_cls(mp2) == MeshBasis
     assert detect_basis_cls(meshpatt_list) == MeshBasis
+    assert detect_basis_cls(mixed_patt_list) == MeshBasis
     assert detect_basis_cls(MeshBasis) == MeshBasis
     assert detect_basis_cls(MeshBasis(meshpatt_list)) == MeshBasis
+
+
+def test_meshbasis_of_perms():
+    p1 = Perm((0, 2, 1))
+    p2 = Perm((2, 0, 1))
+    assert MeshBasis([p1, p2]) == MeshBasis([MeshPatt(p1, []), MeshPatt(p2, [])])
+
+    shading = ((2, 0), (2, 1), (2, 2), (2, 3))
+    mp1 = MeshPatt(p1, shading)
+    mp2 = MeshPatt(p2, shading)
+    assert MeshBasis([p1, p2]) == MeshBasis([p1, p2, mp1, mp2])
+
+    # TypeError: Elements of a basis should all be of type(s) Perm
+    with pytest.raises(TypeError):
+        Basis([mp1, mp2])
+
+    for elmnt in MeshBasis([p1, p2]):
+        assert isinstance(elmnt, MeshPatt)
+
+
+def test_basis_with_empty_perm():
+    basis = Basis([Perm(), Perm((0,))])
+    assert basis == Basis(Perm())
+
+
+def test_meshbasis_with_empty_meshpatt():
+    meshbasis = MeshBasis([MeshPatt(), MeshPatt(Perm((0,)), ())])
+    assert meshbasis == MeshBasis(MeshPatt())
+
+
+def test_meshbasis_with_empty_perm():
+    meshbasis = MeshBasis([MeshPatt(), Perm()])
+    assert meshbasis == MeshBasis(MeshPatt())


### PR DESCRIPTION
Converting all `Perm`s to `MeshPatt`s in `MeshBasis` constructor. This allows for creating a (mesh)basis from a mix of perms and meshpatts and with a syntax such as `Av({Perm((0, 2, 1)), MeshPatt(Perm((1, 2, 0)), [(0, 1), (1, 0), (1, 1), (1, 2), (1, 3), (2, 1), (3, 1)])})`.

Solves issue #67.