### PR TITLE
Mesh patt ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- `MeshPatt`s are now comparable (i.e. a mesh patt is always less then, 
+  equal to or greater than another mesh patt) and therefore sortable
 
 ## [1.2.1] - 2019-09-10
 ### Fixed

--- a/permuta/meshpatt.py
+++ b/permuta/meshpatt.py
@@ -1011,6 +1011,20 @@ class MeshPatt(MeshPatternBase, Patt, Rotatable, Shiftable, Flippable):
     def __bool__(self):
         return bool(self.pattern) or bool(self.shading)
 
+    def __lt__(self, other):
+        return (self.pattern, sorted(self.shading)) < \
+               (other.pattern, sorted(other.shading))
+
+    def __le__(self, other):
+        return (self.pattern, sorted(self.shading)) <= \
+               (other.pattern, sorted(other.shading))
+
+    def __gt__(self, other):
+        return other.__lt__(self)
+
+    def __ge__(self, other):
+        return other.__le__(self)
+
     def __contains__(self, patt):
         """Check if self contains patt.
 

--- a/tests/test_meshpatt.py
+++ b/tests/test_meshpatt.py
@@ -464,6 +464,24 @@ def test_eq():
     assert mesh2copy == mesh2copy
     assert mesh3copy == mesh3copy
 
+
+def test_ordering():
+    # mesh1, mesh2 and mesh3 have different underlying patterns
+    mp1 = MeshPatt(perm1, shad1)
+    mp2 = MeshPatt(perm1, shad2)
+    mp3 = MeshPatt(perm1, shad3)
+
+    # Ensure some ordering of mesh patts (all should be comparable)
+    assert mesh1 > mesh2 or mesh1 <= mesh2
+    assert mp1 < mp2 or mp1 >= mp2
+
+    # Describing lexicographical ordering of mesh patts:
+    #  1) order first by underlying patts
+    #  2) order second by shading [Python list ordering by smallest indices]
+    assert mesh3 < mesh1 < mesh2  # case 1)
+    assert mp1 < mp2 < mp3  # case 2)
+
+
 def test_to_tikz():
     assert (mesh_pattern.to_tikz() ==
 '\\begin{tikzpicture}[scale=.3,baseline=(current bounding box.center)]\n\t\\foreach \\x in {1,...,4} {\n\t\t\\draw[ultra thin] (\\x,0)--(\\x,5); %vline\n\t\t\\draw[ultra thin] (0,\\x)--(5,\\x); %hline\n\t\n\t}\n\t\\fill[pattern color = black!75, pattern=north east lines] (0, 0) rectangle +(1,1);\n\t\\fill[pattern color = black!75, pattern=north east lines] (0, 4) rectangle +(1,1);\n\t\\fill[pattern color = black!75, pattern=north east lines] (2, 1) rectangle +(1,1);\n\t\\fill[pattern color = black!75, pattern=north east lines] (2, 2) rectangle +(1,1);\n\t\\fill[pattern color = black!75, pattern=north east lines] (3, 3) rectangle +(1,1);\n\t\\fill[pattern color = black!75, pattern=north east lines] (4, 0) rectangle +(1,1);\n\t\\fill[pattern color = black!75, pattern=north east lines] (4, 1) rectangle +(1,1);\n\t\\fill[pattern color = black!75, pattern=north east lines] (4, 2) rectangle +(1,1);\n\t\\draw[fill=black] (1,2) circle (5pt);\n\t\\draw[fill=black] (2,4) circle (5pt);\n\t\\draw[fill=black] (3,3) circle (5pt);\n\t\\draw[fill=black] (4,1) circle (5pt);\n\\end{tikzpicture}'


### PR DESCRIPTION
_(Solving #71)_

The `MeshPatt.shading` is a `frozenset` which is not an "orderable" datatype (not always `fs1 < fs2 or fs1 >= fs2` for two frozen sets) so my solution is to cast it to a sorted list every time two `MeshPatt`s are compared. This may not be the most efficient or neat solution so I'm open for ideas on how to do it differently.