### PR TITLE
Complexity improvements for counting inversions (and non-inv)

### DIFF
--- a/permuta/perm.py
+++ b/permuta/perm.py
@@ -1202,7 +1202,17 @@ class Perm(tuple, Patt, Rotatable, Shiftable, Flippable):
             >>> Perm.monotone_increasing(7).count_inversions()
             0
         """
-        return sum(1 for _ in self.inversions())
+        l = len(self) + 1
+        bit = [0] * l
+        for x in reversed(self):
+            i = x + 1
+            while x:
+                bit[0] += bit[x]
+                x &= x - 1
+            while i < l:
+                bit[i] += 1 
+                i += i & -i
+        return bit[0]
 
     def inversions(self):
         """Yield the inversions of the permutation, i.e., the pairs i,j
@@ -1229,7 +1239,8 @@ class Perm(tuple, Patt, Rotatable, Shiftable, Flippable):
             >>> Perm.monotone_increasing(7).count_non_inversions() == (6 * 7)/2
             True
         """
-        return sum(1 for _ in self.non_inversions())
+        n = len(self)
+        return n * (n - 1) // 2 - self.count_inversions()
 
     def non_inversions(self):
         """Yields the non_inversions of the permutation, i.e., the pairs i,j

--- a/permuta/perm.py
+++ b/permuta/perm.py
@@ -1210,7 +1210,7 @@ class Perm(tuple, Patt, Rotatable, Shiftable, Flippable):
                 bit[0] += bit[element]
                 element &= element - 1
             while bit_index < bit_len:
-                bit[bit_index] += 1 
+                bit[bit_index] += 1
                 bit_index += bit_index & -bit_index
         return bit[0]
 

--- a/permuta/perm.py
+++ b/permuta/perm.py
@@ -1206,11 +1206,15 @@ class Perm(tuple, Patt, Rotatable, Shiftable, Flippable):
         bit = [0] * bit_len
         for element in reversed(self):
             bit_index = element + 1
+            # Count lesser elements to the right
             while element:
                 bit[0] += bit[element]
+                # Flip the right most set bit
                 element &= element - 1
+            # Increment frequency for current element
             while bit_index < bit_len:
                 bit[bit_index] += 1
+                # Increase index by the largest power of two that divides it
                 bit_index += bit_index & -bit_index
         return bit[0]
 

--- a/permuta/perm.py
+++ b/permuta/perm.py
@@ -1202,16 +1202,16 @@ class Perm(tuple, Patt, Rotatable, Shiftable, Flippable):
             >>> Perm.monotone_increasing(7).count_inversions()
             0
         """
-        l = len(self) + 1
-        bit = [0] * l
-        for x in reversed(self):
-            i = x + 1
-            while x:
-                bit[0] += bit[x]
-                x &= x - 1
-            while i < l:
-                bit[i] += 1 
-                i += i & -i
+        bit_len = len(self) + 1
+        bit = [0] * bit_len
+        for element in reversed(self):
+            bit_index = element + 1
+            while element:
+                bit[0] += bit[element]
+                element &= element - 1
+            while bit_index < bit_len:
+                bit[bit_index] += 1 
+                bit_index += bit_index & -bit_index
         return bit[0]
 
     def inversions(self):


### PR DESCRIPTION
Binary indexed tree for counting inversion. `O(n*lg(n))` instead of `O(n^2)`.

```Python
from permuta import Perm
from time import time
from random import uniform

perms = [Perm.random(int(uniform(0,1000))) for _ in range(10**4)]

cnt, start = 0, time()
for p in perms:
    cnt += p.old_count_inversions()
end = time()
print(f'Old count inversions:\n  Total: {cnt}\n  Time: {end-start}s')

cnt, start = 0, time()
for p in perms:
    cnt += p.count_inversions()
end = time()
print(f'New count inversions:\n  Total: {cnt}\n  Time: {end-start}s')
```
Output:
```
Old count inversions:
  Total: 821874512
  Time: 434.229594707489s
New count inversions:
  Total: 821874512
  Time: 11.64700984954834s
```