### PR TITLE
add cli for quick enumeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 ## Added
-- A quick command line interface to look the enumeration of a permutation class.
+- A quick command line interface to compute the enumeration of a permutation class.
 
 ## 1.4.2 - 2020-06-17
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+## Added
+- A quick command line interface to look the enumeration of a permutation class.
 
 ## 1.4.2 - 2020-06-17
 ### Fixed

--- a/permuta/cli.py
+++ b/permuta/cli.py
@@ -1,0 +1,42 @@
+import argparse
+import signal
+import sys
+
+from permuta import Av, Perm
+
+parser = argparse.ArgumentParser(
+    description="A tool quickly get the enumeration of permutation classes"
+)
+parser.add_argument(
+    "basis",
+    help="The basis as a string where the permutations are separated by '_' (e.g. '231_4321')",
+)
+
+
+def signal_handler(sig, frame):
+    print()
+    print("Exiting.")
+    sys.exit(0)
+
+
+def main():
+    args = parser.parse_args()
+    basis = []
+    for perm_str in args.basis.split("_"):
+        perm_tuple = tuple(map(int, perm_str))
+        if 0 not in perm_tuple:
+            perm_tuple = tuple(i - 1 for i in perm_tuple)
+        perm = Perm(perm_tuple, check=True)
+        basis.append(perm)
+    perm_class = Av(basis)
+    n = 0
+    print(f"Enumerating {perm_class}. Press Ctrl+C to exit.")
+    signal.signal(signal.SIGINT, signal_handler)
+    while True:
+        num = len(list(perm_class.of_length(n)))
+        print(f"{num}, ", end="", flush=True)
+        n += 1
+
+
+if __name__ == "__main__":
+    main()

--- a/permuta/cli.py
+++ b/permuta/cli.py
@@ -4,15 +4,6 @@ import sys
 
 from permuta import Av, Perm
 
-parser = argparse.ArgumentParser(
-    description="A tool quickly get the enumeration of permutation classes"
-)
-parser.add_argument(
-    "basis",
-    help="The basis as a string where the permutations are separated by '_' "
-    "(e.g. '231_4321')",
-)
-
 
 def signal_handler(sig, frame):
     print()
@@ -20,8 +11,7 @@ def signal_handler(sig, frame):
     sys.exit(0)
 
 
-def main():
-    args = parser.parse_args()
+def enumerate_class(args):
     basis = []
     for perm_str in args.basis.split("_"):
         perm_tuple = tuple(map(int, perm_str))
@@ -37,6 +27,30 @@ def main():
         num = len(list(perm_class.of_length(n)))
         print(f"{num}, ", end="", flush=True)
         n += 1
+
+
+parser = argparse.ArgumentParser(description="A set of tools to work with permutations")
+subparsers = parser.add_subparsers(title="subcommands")
+
+
+# The count command
+count_parser = subparsers.add_parser(
+    "count", description="A tool to quickly get the enumeration of permutation classes"
+)
+count_parser.set_defaults(func=enumerate_class)
+count_parser.add_argument(
+    "basis",
+    help="The basis as a string where the permutations are separated by '_' "
+    "(e.g. '231_4321')",
+)
+
+
+def main():
+    args = parser.parse_args()
+    if not hasattr(args, "func"):
+        parser.error("Invalid command")
+    args.func(args)
+    sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/permuta/cli.py
+++ b/permuta/cli.py
@@ -9,7 +9,8 @@ parser = argparse.ArgumentParser(
 )
 parser.add_argument(
     "basis",
-    help="The basis as a string where the permutations are separated by '_' (e.g. '231_4321')",
+    help="The basis as a string where the permutations are separated by '_' "
+    "(e.g. '231_4321')",
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -40,5 +40,5 @@ setup(
         "Topic :: Education",
         "Topic :: Scientific/Engineering :: Mathematics",
     ],
-    entry_points={"console_scripts": ["foo=permuta.cli:main"]},
+    entry_points={"console_scripts": ["permtools=permuta.cli:main"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -40,4 +40,5 @@ setup(
         "Topic :: Education",
         "Topic :: Scientific/Engineering :: Mathematics",
     ],
+    entry_points={"console_scripts": ["foo=permuta.cli:main"]},
 )


### PR DESCRIPTION
I've added a cli to quickly enumeration a class from a string because I'm tired of alwasy doing it manually. It's pretty straightforward, you just type `foo 132_4321` and you get
```
Enumerating Av(021, 3210). Press Ctrl+C to exit.
1, 1, 2, 5, 13, 31, 66, 127, 225, 373, 586, 881, 1277, 1795, 2458, 3291, 4321, 5577, ^C
Exiting.
```
The terms just keep coming until you press Ctrl+C.

I first wanted to name the tool `permuta` but I can't as is seems to create conflicts with the package name. I gave it the temporary name `foo`, I'll be happy to get name suggestion.