### PR TITLE
Typing for permuta/perm.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ matrix:
     - python: 3.8
       env: TOXENV=flake8
     - python: 3.8
+      env: TOXENV=mypy
+    - python: 3.8
       env: TOXENV=black
 
     - python: 3.6

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,5 @@
+[mypy]
+warn_return_any = True
+warn_unused_configs = True
+warn_no_return = False
+files = permuta/**/*.py

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,3 +3,6 @@ warn_return_any = True
 warn_unused_configs = True
 warn_no_return = False
 files = permuta/**/*.py
+
+[mypy-sympy.*]
+ignore_missing_imports = True

--- a/permuta/_perm_set/unbounded/all/permset_all.py
+++ b/permuta/_perm_set/unbounded/all/permset_all.py
@@ -92,11 +92,7 @@ class PermSetAllSpecificLength(PermSetFiniteSpecificLength):
         return Perm.unrank(key, self.length)
 
     def __iter__(self):
-        # Need to return new instance because permutations of itertools
-        # depletes self
-        # This probably needs looking into because the iter isn't a subclass of
-        # PermSet
-        return PermSetAllSpecificLengthIterator(self.domain)
+        return (Perm(x) for x in itertools.permutations(self.domain))
 
     def __len__(self):
         return factorial(self.length)
@@ -106,11 +102,6 @@ class PermSetAllSpecificLength(PermSetFiniteSpecificLength):
 
     def __str__(self):
         return "<The set of all perms of length {}>".format(self.length)
-
-
-class PermSetAllSpecificLengthIterator(itertools.permutations):
-    def __next__(self):
-        return Perm(super(PermSetAllSpecificLengthIterator, self).__next__())
 
 
 class PermSetAllFiniteLengthSubset(PermSetFinite):

--- a/permuta/_perm_set/unbounded/described/avoiding/avoiding.py
+++ b/permuta/_perm_set/unbounded/described/avoiding/avoiding.py
@@ -1,6 +1,7 @@
 import functools
 import multiprocessing
 import random
+from typing import Any, Dict
 
 from .....descriptors.basis import AbstractBasis, Basis
 from .....perm import Perm
@@ -14,7 +15,7 @@ class Avoiding(PermSetDescribed):
     """The base class for all avoidance classes."""
 
     # NOTE: Monkey patching of default subclass happens at end of file
-    DESCRIPTOR_CLASS = AbstractBasis
+    DESCRIPTOR_CLASS: Any = AbstractBasis
 
     @property
     def basis(self):
@@ -35,7 +36,7 @@ class Avoiding(PermSetDescribed):
 
 class AvoidingGeneric(Avoiding):
     # Empty basis is dispatched to correct/another class (AvoidingEmpty)
-    __CLASS_CACHE = {}
+    __CLASS_CACHE: Dict = {}
     _CACHE_LOCK = multiprocessing.Lock()
 
     def __new__(cls, basis):

--- a/permuta/_perm_set/unbounded/described/avoiding/avoiding_length_0/avoiding_empty.py
+++ b/permuta/_perm_set/unbounded/described/avoiding/avoiding_length_0/avoiding_empty.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from ......descriptors.basis import Basis
 from ......perm import Perm
 from .....finite.permset_static import PermSetStatic
@@ -7,7 +9,7 @@ from ..avoiding import Avoiding
 class AvoidingEmpty(Avoiding):
     """The empty perm set class."""
 
-    DESCRIPTOR = Basis(Perm())
+    DESCRIPTOR: Any = Basis(Perm())
     __CLASS_CACHE = None
 
     def __new__(cls, basis):

--- a/permuta/_perm_set/unbounded/described/permset_described.py
+++ b/permuta/_perm_set/unbounded/described/permset_described.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from ..permset_unbounded import PermSetUnbounded
 
 
@@ -7,7 +9,7 @@ class PermSetDescribed(PermSetUnbounded):
     # TODO: Make things abstract properties as a solution?
 
     # TODO: These two attribute needs to be defined in all immediate subclasses
-    DEFAULT_CLASS = None
+    DEFAULT_CLASS: Any = None
     DESCRIPTOR_CLASS = None
 
     # TODO: This needs to be defined in classes for specific descriptors

--- a/permuta/enumeration_strategies/__init__.py
+++ b/permuta/enumeration_strategies/__init__.py
@@ -1,11 +1,15 @@
+from typing import List
+
 from .core_strategies import core_strategies
 from .insertion_encodable import InsertionEncodingStrategy
 
-fast_enumeration_strategies = [InsertionEncodingStrategy] + core_strategies
+fast_enumeration_strategies: List = [InsertionEncodingStrategy] + core_strategies
 
-long_enumeration_strategies = []
+long_enumeration_strategies: List = []
 
-all_enumeration_strategies = fast_enumeration_strategies + long_enumeration_strategies
+all_enumeration_strategies: List = (
+    fast_enumeration_strategies + long_enumeration_strategies
+)
 
 
 def find_strategies(basis, long_runnning=True):

--- a/permuta/enumeration_strategies/core_strategies.py
+++ b/permuta/enumeration_strategies/core_strategies.py
@@ -1,4 +1,5 @@
 from abc import abstractproperty, abstractstaticmethod
+from typing import List
 
 from permuta import Av, MeshPatt, Perm
 from permuta.enumeration_strategies.abstract_strategy import (
@@ -20,7 +21,7 @@ class CoreStrategy(EnumerationStrategyWithSymmetry):
     """
 
     @abstractproperty
-    def patterns_needed():
+    def patterns_needed(self):
         """
         Return the set of patterns that are needed for the strategy to be
         useful.
@@ -221,7 +222,7 @@ class Ru2143CoreStrategy(CoreStrategy):
         return patt.avoids(mp) and last_skew_component(patt) not in Av([Perm((1, 0))])
 
 
-core_strategies = [
+core_strategies: List = [
     RuCuCoreStrategy,
     RdCdCoreStrategy,
     RuCuRdCdCoreStrategy,

--- a/permuta/interfaces/flippable.py
+++ b/permuta/interfaces/flippable.py
@@ -1,9 +1,9 @@
 import abc
 
-ABC = abc.ABCMeta("ABC", (object,), {})
+# ABC = abc.ABCMeta("ABC", (object,), {})
 
 
-class Flippable(ABC):
+class Flippable(abc.ABC):
     @abc.abstractmethod
     def flip_horizontal(self):
         """Return self flipped horizontally."""

--- a/permuta/interfaces/flippable.py
+++ b/permuta/interfaces/flippable.py
@@ -1,7 +1,5 @@
 import abc
 
-# ABC = abc.ABCMeta("ABC", (object,), {})
-
 
 class Flippable(abc.ABC):
     @abc.abstractmethod

--- a/permuta/interfaces/patt.py
+++ b/permuta/interfaces/patt.py
@@ -1,10 +1,10 @@
 import abc
-from typing import Iterator, List, Tuple, Union
+from typing import Iterator, List, Tuple, Type, Union
 
-ABC = abc.ABCMeta("ABC", (object,), {})
+# ABC: Type = abc.ABCMeta("ABC", (object,), {})
 
 
-class Patt(ABC):
+class Patt(abc.ABC):
     def avoided_by(self, *perms):
         """Check if self is avoided by perms.
 
@@ -53,3 +53,11 @@ class Patt(ABC):
     ) -> Union[Iterator[List[Tuple[int]]], Iterator[Tuple[()]]]:
         """Find all indices of occurrences of self in perm."""
         pass
+
+    @abc.abstractmethod
+    def __len__(self):
+        pass
+
+    @property
+    def pattern(self):
+        return self

--- a/permuta/interfaces/patt.py
+++ b/permuta/interfaces/patt.py
@@ -1,8 +1,6 @@
 import abc
 from typing import Iterator, List, Tuple, Union
 
-# ABC: Type = abc.ABCMeta("ABC", (object,), {})
-
 
 class Patt(abc.ABC):
     def avoided_by(self, *perms):
@@ -50,7 +48,7 @@ class Patt(abc.ABC):
     @abc.abstractmethod
     def occurrences_in(
         self, perm
-    ) -> Union[Iterator[List[Tuple[int]]], Iterator[Tuple[()]]]:
+    ) -> Union[Iterator[List[Tuple[int, ...]]], Iterator[Tuple[()]]]:
         """Find all indices of occurrences of self in perm."""
         pass
 

--- a/permuta/interfaces/patt.py
+++ b/permuta/interfaces/patt.py
@@ -1,4 +1,5 @@
 import abc
+from typing import Iterator, List, Tuple, Union
 
 ABC = abc.ABCMeta("ABC", (object,), {})
 
@@ -32,7 +33,7 @@ class Patt(ABC):
         """
         return all(self in perm for perm in perms)
 
-    def count_occurrences_in(self, perm):
+    def count_occurrences_in(self, perm) -> int:
         """Count the number of occurrences of self in perm.
 
         Args:
@@ -47,6 +48,8 @@ class Patt(ABC):
         return sum(1 for _ in self.occurrences_in(perm))
 
     @abc.abstractmethod
-    def occurrences_in(self, perm):
+    def occurrences_in(
+        self, perm
+    ) -> Union[Iterator[List[Tuple[int]]], Iterator[Tuple[()]]]:
         """Find all indices of occurrences of self in perm."""
         pass

--- a/permuta/interfaces/patt.py
+++ b/permuta/interfaces/patt.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Iterator, List, Tuple, Type, Union
+from typing import Iterator, List, Tuple, Union
 
 # ABC: Type = abc.ABCMeta("ABC", (object,), {})
 

--- a/permuta/interfaces/rotatable.py
+++ b/permuta/interfaces/rotatable.py
@@ -1,9 +1,9 @@
 import abc
 
-ABC = abc.ABCMeta("ABC", (object,), {})
+# ABC = abc.ABCMeta("ABC", (object,), {})
 
 
-class Rotatable(ABC):
+class Rotatable(abc.ABC):
     def rotate(self, times=1):
         """Return self rotated 90 degrees to the right."""
         return self._rotate(times)

--- a/permuta/interfaces/rotatable.py
+++ b/permuta/interfaces/rotatable.py
@@ -1,7 +1,5 @@
 import abc
 
-# ABC = abc.ABCMeta("ABC", (object,), {})
-
 
 class Rotatable(abc.ABC):
     def rotate(self, times=1):

--- a/permuta/interfaces/shiftable.py
+++ b/permuta/interfaces/shiftable.py
@@ -1,9 +1,9 @@
 import abc
 
-ABC = abc.ABCMeta("ABC", (object,), {})
+# ABC = abc.ABCMeta("ABC", (object,), {})
 
 
-class Shiftable(ABC):
+class Shiftable(abc.ABC):
     @abc.abstractmethod
     def shift_right(self, times=1):
         """Return self shifted times steps to the right.

--- a/permuta/interfaces/shiftable.py
+++ b/permuta/interfaces/shiftable.py
@@ -1,7 +1,5 @@
 import abc
 
-# ABC = abc.ABCMeta("ABC", (object,), {})
-
 
 class Shiftable(abc.ABC):
     @abc.abstractmethod

--- a/permuta/perm.py
+++ b/permuta/perm.py
@@ -16,7 +16,7 @@ from .misc.iterable_floor_and_ceiling import left_floor_and_ceiling
 __all__ = ("Perm",)
 
 
-class Perm(tuple, Patt, Rotatable, Shiftable, Flippable):
+class Perm(Tuple[int], Patt, Rotatable, Shiftable, Flippable):
     """A perm class."""
 
     _TYPE_ERROR: ClassVar[str] = "'{}' object is not a perm"

--- a/permuta/perm.py
+++ b/permuta/perm.py
@@ -5,7 +5,18 @@ import math
 import numbers
 import operator
 import random
-from typing import ClassVar, Dict, Iterable, Iterator, List, Optional, Set, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    ClassVar,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
 
 from .interfaces.flippable import Flippable
 from .interfaces.patt import Patt
@@ -15,8 +26,13 @@ from .misc.iterable_floor_and_ceiling import left_floor_and_ceiling
 
 __all__ = ("Perm",)
 
+if TYPE_CHECKING:
+    tuple_class = Tuple[int]
+else:
+    tuple_class = tuple
 
-class Perm(tuple, Patt, Rotatable, Shiftable, Flippable):
+
+class Perm(tuple_class, Patt, Rotatable, Shiftable, Flippable):
     """A perm class."""
 
     _TYPE_ERROR: ClassVar[str] = "'{}' object is not a perm"

--- a/permuta/perm.py
+++ b/permuta/perm.py
@@ -74,7 +74,7 @@ class Perm(tuple, Patt, Rotatable, Shiftable, Flippable):
                 raise ValueError("Duplicate element: {}".format(val))
             used[val] = True
 
-    _to_standard_cache: Dict[Tuple, "Perm"] = {}
+    _to_standard_cache: ClassVar[Dict[Tuple, "Perm"]] = {}
 
     @classmethod
     def to_standard(cls, iterable: Iterable) -> "Perm":
@@ -149,7 +149,7 @@ class Perm(tuple, Patt, Rotatable, Shiftable, Flippable):
         # TODO: throw exception when not a string
 
     @classmethod
-    def one_based(cls, iterable: Iterable) -> "Perm":
+    def one_based(cls, iterable: Iterable[int]) -> "Perm":
         """A way to enter a perm in the traditional permuta way.
 
         Examples:
@@ -352,9 +352,9 @@ class Perm(tuple, Patt, Rotatable, Shiftable, Flippable):
                 raise TypeError(Perm._TYPE_ERROR.format(repr(other)))
             if len(other) != len(self):
                 raise ValueError("Perm length mismatch")
-        return Perm(self._composed_value(idx, others) for idx in range(len(self)))
+        return Perm(self._composed_value(idx, *others) for idx in range(len(self)))
 
-    def _composed_value(self, idx, others):
+    def _composed_value(self, idx: int, *others: "Perm") -> int:
         for other in reversed(others):
             idx = other[idx]
         return self[idx]
@@ -539,7 +539,7 @@ class Perm(tuple, Patt, Rotatable, Shiftable, Flippable):
 
     def contract_bonds(self) -> None:
         # TODO: reimplement by calling contract_{inc,dec}_bonds or remove
-        pass
+        raise NotImplementedError()
 
     #
     # Methods for basic Perm transforming

--- a/permuta/perm.py
+++ b/permuta/perm.py
@@ -16,7 +16,7 @@ from .misc.iterable_floor_and_ceiling import left_floor_and_ceiling
 __all__ = ("Perm",)
 
 
-class Perm(Tuple[int], Patt, Rotatable, Shiftable, Flippable):
+class Perm(tuple, Patt, Rotatable, Shiftable, Flippable):
     """A perm class."""
 
     _TYPE_ERROR: ClassVar[str] = "'{}' object is not a perm"

--- a/permuta/perm.py
+++ b/permuta/perm.py
@@ -41,7 +41,7 @@ class Perm(tuple_class, Patt, Rotatable, Shiftable, Flippable):
     # Methods returning a single Perm instance
     #
 
-    def __new__(cls, iterable: Iterable = (), check: bool = False) -> "Perm":
+    def __new__(cls, iterable: Iterable[int] = (), check: bool = False) -> "Perm":
         """Return a Perm instance.
 
         Raises:
@@ -62,7 +62,7 @@ class Perm(tuple_class, Patt, Rotatable, Shiftable, Flippable):
         """
         return tuple.__new__(cls, iterable)
 
-    def __init__(self, iterable: Iterable = (), check: bool = False) -> None:
+    def __init__(self, iterable: Iterable[int] = (), check: bool = False) -> None:
         # Cache for data used when finding occurrences of self in a perm
         self._cached_pattern_details: Optional[
             List[Tuple[Optional[int], Optional[int], int, int]]
@@ -1741,7 +1741,7 @@ class Perm(tuple_class, Patt, Rotatable, Shiftable, Flippable):
         patt: "Patt",
         self_colours: List[int] = None,
         patt_colours: List[int] = None,
-    ) -> Union[Iterator[List[Tuple[int]]], Iterator[Tuple[()]]]:
+    ) -> Union[Iterator[List[Tuple[int, ...]]], Iterator[Tuple[()]]]:
         """Find all indices of occurrences of self in patt. If the optional colours
         are provided, in an occurrences the colours of the patterns have to match the
         colours of the permutation.
@@ -1842,7 +1842,7 @@ class Perm(tuple_class, Patt, Rotatable, Shiftable, Flippable):
 
     def occurrences_of(
         self, patt: "Patt"
-    ) -> Union[Iterator[List[Tuple[int]]], Iterator[Tuple[()]]]:
+    ) -> Union[Iterator[List[Tuple[int, ...]]], Iterator[Tuple[()]]]:
         """Find all indices of occurrences of patt in self. This method is complementary
         to permuta.Perm.occurrences_in. It just calls patt.occurrences_in(self)
         internally. See permuta.Perm.occurrences_in for documentation.
@@ -2007,6 +2007,8 @@ class Perm(tuple_class, Patt, Rotatable, Shiftable, Flippable):
 
     def __add__(self, other) -> "Perm":
         """Return the direct sum of the perms self and other."""
+        if not isinstance(other, Perm):
+            raise NotImplementedError
         return self.direct_sum(other)
 
     def __sub__(self, other) -> "Perm":

--- a/permuta/perm.py
+++ b/permuta/perm.py
@@ -2007,8 +2007,6 @@ class Perm(tuple_class, Patt, Rotatable, Shiftable, Flippable):
 
     def __add__(self, other) -> "Perm":
         """Return the direct sum of the perms self and other."""
-        if not isinstance(other, Perm):
-            raise NotImplementedError
         return self.direct_sum(other)
 
     def __sub__(self, other) -> "Perm":

--- a/permuta/permutils/insertion_encodable.py
+++ b/permuta/permutils/insertion_encodable.py
@@ -1,5 +1,7 @@
 """Function for testing if a basis has a regular insertion encoding."""
 
+from typing import Dict, Tuple
+
 
 def is_incr_next_incr(perm):
     for i in range(len(perm) - 1):
@@ -41,7 +43,7 @@ def is_decr_next_decr(perm):
     return True
 
 
-mem = dict()
+mem: Dict[Tuple, int] = dict()
 
 
 def insertion_encodable_properties(perm):

--- a/permuta/permutils/polynomial.py
+++ b/permuta/permutils/polynomial.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 # Will return the set of polynomial types it intersects with
 #   (W_++, W+-, W^-1 ++, L_2, L_2^R etc)
 # 1: W++
@@ -10,7 +12,7 @@
 # 8: Winv--
 # 9: L2
 # 10: L2inv
-mem = {}
+mem: Dict = {}
 
 
 def types(perm):

--- a/tests/test_perm.py
+++ b/tests/test_perm.py
@@ -1056,14 +1056,18 @@ def test_threepats():
     assert all(v == 0 for v in Perm().threepats().values())
     assert all(v == 0 for v in Perm((0,)).threepats().values())
     assert all(v == 0 for v in Perm((0, 1)).threepats().values())
-    assert Perm((2, 1, 0, 3)).threepats() == {
-        Perm((0, 1, 2)): 0,
-        Perm((0, 2, 1)): 0,
-        Perm((1, 0, 2)): 3,
-        Perm((1, 2, 0)): 0,
-        Perm((2, 0, 1)): 0,
-        Perm((2, 1, 0)): 1,
-    }
+    assert (
+        lambda counter: all(
+            (
+                counter[Perm((0, 1, 2))] == 0,
+                counter[Perm((0, 2, 1))] == 0,
+                counter[Perm((1, 0, 2))] == 3,
+                counter[Perm((1, 2, 0))] == 0,
+                counter[Perm((2, 0, 1))] == 0,
+                counter[Perm((2, 1, 0))] == 1,
+            )
+        )
+    )(Perm((2, 1, 0, 3)).threepats())
     for _ in range(20):
         perm = Perm.random(random.randint(0, 20))
         threepatdict = perm.threepats()
@@ -1075,32 +1079,36 @@ def test_fourpats():
     assert all(v == 0 for v in Perm().fourpats().values())
     assert all(v == 0 for v in Perm((0,)).fourpats().values())
     assert all(v == 0 for v in Perm((0, 1)).fourpats().values())
-    assert Perm((1, 0, 3, 5, 2, 4)).fourpats() == {
-        Perm((0, 1, 2, 3)): 0,
-        Perm((0, 1, 3, 2)): 2,
-        Perm((0, 2, 1, 3)): 2,
-        Perm((0, 2, 3, 1)): 2,
-        Perm((0, 3, 1, 2)): 2,
-        Perm((0, 3, 2, 1)): 0,
-        Perm((1, 0, 2, 3)): 3,
-        Perm((1, 0, 3, 2)): 3,
-        Perm((1, 2, 0, 3)): 0,
-        Perm((1, 2, 3, 0)): 0,
-        Perm((1, 3, 0, 2)): 1,
-        Perm((1, 3, 2, 0)): 0,
-        Perm((2, 0, 1, 3)): 0,
-        Perm((2, 0, 3, 1)): 0,
-        Perm((2, 1, 0, 3)): 0,
-        Perm((2, 1, 3, 0)): 0,
-        Perm((2, 3, 0, 1)): 0,
-        Perm((2, 3, 1, 0)): 0,
-        Perm((3, 0, 1, 2)): 0,
-        Perm((3, 0, 2, 1)): 0,
-        Perm((3, 1, 0, 2)): 0,
-        Perm((3, 1, 2, 0)): 0,
-        Perm((3, 2, 0, 1)): 0,
-        Perm((3, 2, 1, 0)): 0,
-    }
+    assert (
+        lambda counter: all(
+            (
+                counter[Perm((0, 1, 2, 3))] == 0,
+                counter[Perm((0, 1, 3, 2))] == 2,
+                counter[Perm((0, 2, 1, 3))] == 2,
+                counter[Perm((0, 2, 3, 1))] == 2,
+                counter[Perm((0, 3, 1, 2))] == 2,
+                counter[Perm((0, 3, 2, 1))] == 0,
+                counter[Perm((1, 0, 2, 3))] == 3,
+                counter[Perm((1, 0, 3, 2))] == 3,
+                counter[Perm((1, 2, 0, 3))] == 0,
+                counter[Perm((1, 2, 3, 0))] == 0,
+                counter[Perm((1, 3, 0, 2))] == 1,
+                counter[Perm((1, 3, 2, 0))] == 0,
+                counter[Perm((2, 0, 1, 3))] == 0,
+                counter[Perm((2, 0, 3, 1))] == 0,
+                counter[Perm((2, 1, 0, 3))] == 0,
+                counter[Perm((2, 1, 3, 0))] == 0,
+                counter[Perm((2, 3, 0, 1))] == 0,
+                counter[Perm((2, 3, 1, 0))] == 0,
+                counter[Perm((3, 0, 1, 2))] == 0,
+                counter[Perm((3, 0, 2, 1))] == 0,
+                counter[Perm((3, 1, 0, 2))] == 0,
+                counter[Perm((3, 1, 2, 0))] == 0,
+                counter[Perm((3, 2, 0, 1))] == 0,
+                counter[Perm((3, 2, 1, 0))] == 0,
+            )
+        )
+    )(Perm((1, 0, 3, 5, 2, 4)).fourpats())
     for _ in range(20):
         perm = Perm.random(random.randint(0, 20))
         fourpatdict = perm.fourpats()

--- a/tests/test_perm.py
+++ b/tests/test_perm.py
@@ -315,26 +315,26 @@ def test_compose():
     assert p4 * p5 * p6 == p7
     assert p5 * p6 * p7 * p4 == p7
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AssertionError):
         p1.compose(None)
-    with pytest.raises(TypeError):
+    with pytest.raises(AssertionError):
         p1 * None
-    with pytest.raises(TypeError):
+    with pytest.raises(AssertionError):
         p2.compose(p2, None)
-    with pytest.raises(TypeError):
+    with pytest.raises(AssertionError):
         p3.compose(1237)
-    with pytest.raises(TypeError):
+    with pytest.raises(AssertionError):
         p5 * ("hahaha")
-    with pytest.raises(TypeError):
+    with pytest.raises(AssertionError):
         p5 * (p1,)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(AssertionError):
         p1.compose(p0)
-    with pytest.raises(ValueError):
+    with pytest.raises(AssertionError):
         p0.compose(p5)
-    with pytest.raises(ValueError):
+    with pytest.raises(AssertionError):
         p2.compose(p3, p0)
-    with pytest.raises(ValueError):
+    with pytest.raises(AssertionError):
         p4.compose(p5, p6, p1)
 
 
@@ -348,11 +348,6 @@ def test_insert():
     assert Perm((0, 3, 1, 2)).insert(3, 4) == Perm((0, 3, 1, 4, 2))
     assert Perm((0, 3, 1, 2)).insert(3, 3) == Perm((0, 4, 1, 3, 2))
     assert Perm((0, 3, 1, 2)).insert(1, 0) == Perm((1, 0, 4, 2, 3))
-
-    with pytest.raises(TypeError):
-        Perm((2, 1, 0, 3)).insert(new_element="hehe")
-    with pytest.raises(TypeError):
-        Perm((2, 1, 0, 3)).insert(3, "hehe")
 
     with pytest.raises(ValueError):
         Perm((2, 1, 0, 3)).insert(2, 100)
@@ -410,11 +405,6 @@ def test_inflate():
         (2, 0, 1, 3, 4)
     )
     assert Perm((0, 1)).inflate([Perm(), Perm()]) == Perm()
-
-    with pytest.raises(TypeError):
-        Perm((0, 1, 2, 3)).inflate(237)
-    with pytest.raises(TypeError):
-        Perm((0, 1, 2, 3)).inflate("hehe")
 
 
 # TODO: The following three functions have yet to be implemented
@@ -1267,12 +1257,10 @@ def test_call_1():
     p = Perm((0, 1, 2, 3))
     for i in range(len(p)):
         assert p(i) == i
-    with pytest.raises(ValueError):
+    with pytest.raises(AssertionError):
         p(-1)
-    with pytest.raises(ValueError):
+    with pytest.raises(AssertionError):
         p(4)
-    with pytest.raises(TypeError):
-        p("abc")
 
 
 def test_call_2():
@@ -1282,12 +1270,10 @@ def test_call_2():
     assert p(2) == 0
     assert p(3) == 2
     assert p(4) == 1
-    with pytest.raises(ValueError):
+    with pytest.raises(AssertionError):
         p(-1)
-    with pytest.raises(ValueError):
+    with pytest.raises(AssertionError):
         p(5)
-    with pytest.raises(TypeError):
-        p([1, 2, 3])
 
 
 def test_eq():

--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,13 @@ deps =
 commands =
     flake8 --isort-show-traceback permuta tests setup.py
 
+[testenv:mypy]
+description = run mypy (static type checker)
+basepython = {[default]basepython}
+deps =
+    mypy==0.782
+commands = mypy
+
 [testenv:black]
 description = check that comply with autoformating
 basepython = {[default]basepython}


### PR DESCRIPTION
Typing. Naming standardized for perm length and indices and elements in perms. Some refactoring. In `permuta/perm.py`.