### PR TITLE
CI update for 3.9 

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,16 +9,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python: 3.8
+          - python: 3.9
             toxenv: flake8
             os: ubuntu-latest
-          - python: 3.8
+          - python: 3.9
             toxenv: mypy
             os: ubuntu-latest
-          - python: 3.8
+          - python: 3.9
             toxenv: pylint
             os: ubuntu-latest
-          - python: 3.8
+          - python: 3.9
             toxenv: black
             os: ubuntu-latest
 
@@ -31,18 +31,21 @@ jobs:
           - python: 3.8
             toxenv: py38
             os: ubuntu-latest
-          - python: 3.9-dev
+          - python: 3.9
             toxenv: py39
+            os: ubuntu-latest
+          - python: 3.10-dev
+            toxenv: py310
             os: ubuntu-latest
           - python: pypy3
             toxenv: pypy36
             os: ubuntu-latest
 
-          - python: 3.8
-            toxenv: py38
+          - python: 3.9
+            toxenv: py39
             os: macos-latest
-          - python: 3.8
-            toxenv: py38
+          - python: 3.9
+            toxenv: py39
             os: windows-latest
 
     runs-on: ${{ matrix.os }}

--- a/.pylintrc
+++ b/.pylintrc
@@ -9,7 +9,8 @@ ignore= tests
 init-hook="from pylint.config import find_pylintrc; import os, sys; sys.path.append(os.path.dirname(find_pylintrc())+'/permuta')"
 disable=bad-continuation, 
         missing-module-docstring,
-        fixme
+        fixme,
+        unsubscriptable-object
 good-names=i,j,n,k,x,y,_
 
 [SIMILARITIES]

--- a/permuta/__init__.py
+++ b/permuta/__init__.py
@@ -1,6 +1,8 @@
 from .patterns import BivincularPatt, CovincularPatt, MeshPatt, Perm, VincularPatt
 from .perm_sets.permset import Av, Basis, MeshBasis
 
+__version__ = "2.0.2"
+
 __all__ = [
     "Perm",
     "Av",

--- a/permuta/patterns/perm.py
+++ b/permuta/patterns/perm.py
@@ -2133,8 +2133,7 @@ class Perm(TupleType, Patt):
         return self.compose(other)
 
     def __repr__(self) -> "str":
-        # pylint: disable = super-with-arguments, bad-option-value
-        return f"Perm({super(Perm, self).__repr__()})"
+        return f"Perm({tuple.__repr__(self)})"
 
     def __str__(self) -> "str":
         if not self:

--- a/permuta/patterns/perm.py
+++ b/permuta/patterns/perm.py
@@ -1,6 +1,4 @@
-# pylint: disable=super-init-not-called
 # pylint: disable=too-many-lines
-# pylint: disable=too-many-public-methods
 
 import bisect
 import collections
@@ -42,6 +40,8 @@ ApplyType = TypeVar("ApplyType")
 class Perm(TupleType, Patt):
     """A perm class."""
 
+    # pylint: disable=too-many-public-methods
+
     _TO_STANDARD_CACHE: ClassVar[Dict[Tuple, "Perm"]] = {}
 
     def __new__(cls, iterable: Iterable[int] = ()) -> "Perm":
@@ -56,6 +56,7 @@ class Perm(TupleType, Patt):
         return tuple.__new__(cls, iterable)
 
     def __init__(self, _iterable: Iterable[int] = ()) -> None:
+        # pylint: disable=super-init-not-called
         # Cache for data used when finding occurrences of self in a perm
         self._cached_pattern_details: Optional[List[Tuple[int, int, int, int]]] = None
 
@@ -2132,6 +2133,7 @@ class Perm(TupleType, Patt):
         return self.compose(other)
 
     def __repr__(self) -> "str":
+        # pylint: disable = super-with-arguments
         return f"Perm({super(Perm, self).__repr__()})"
 
     def __str__(self) -> "str":

--- a/permuta/patterns/perm.py
+++ b/permuta/patterns/perm.py
@@ -2133,7 +2133,7 @@ class Perm(TupleType, Patt):
         return self.compose(other)
 
     def __repr__(self) -> "str":
-        # pylint: disable = super-with-arguments
+        # pylint: disable = super-with-arguments, bad-option-value
         return f"Perm({super(Perm, self).__repr__()})"
 
     def __str__(self) -> "str":

--- a/permuta/perm_sets/permset.py
+++ b/permuta/perm_sets/permset.py
@@ -12,6 +12,8 @@ class AvBase(NamedTuple):
     __init__ in Av.
     """
 
+    # pylint: disable=inherit-non-class,too-few-public-methods
+
     basis: Union[Basis, MeshBasis]
     cache: List[Dict[Perm, Optional[List[int]]]]
 

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,17 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname), encoding="utf-8").read()
 
 
+def get_version(rel_path):
+    for line in read(rel_path).splitlines():
+        if line.startswith("__version__"):
+            delim = '"' if '"' in line else "'"
+            return line.split(delim)[1]
+    raise RuntimeError("Unable to find version string.")
+
+
 setup(
     name="permuta",
-    version="2.0.2",
+    version=get_version("permuta/__init__.py"),
     author="Permuta Triangle",
     author_email="permutatriangle@gmail.com",
     description="A comprehensive high performance permutation library.",
@@ -24,7 +32,7 @@ setup(
         "Source": "https://github.com/PermutaTriangle/Permuta",
         "Tracker": "https://github.com/PermutaTriangle/Permuta/issues",
     },
-    packages=find_packages(),
+    packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     package_data={"permuta": ["py.typed"]},
     long_description=read("README.rst"),
     python_requires=">=3.6",
@@ -38,6 +46,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Education",

--- a/tox.ini
+++ b/tox.ini
@@ -6,11 +6,11 @@
 [tox]
 envlist =
     flake8, mypy, pylint, black
-    py{36,37,38,39},
+    py{36,37,38,39,310},
     pypy36
 
 [default]
-basepython=python3.8
+basepython=python3.9
 
 [testenv]
 description = run test
@@ -19,6 +19,7 @@ basepython =
     py37: python3.7
     py38: python3.8
     py39: python3.9
+    py310: python3.10
     pypy36: pypy3
 deps =
     pytest==6.1.0


### PR DESCRIPTION
* 3.9 as default
* 3.10 dev builds
* version in `permuta/__init__.py`
* stop packaging test modules